### PR TITLE
Patch 2

### DIFF
--- a/src/v1_TeslaMateAPICarsChargesDetails.go
+++ b/src/v1_TeslaMateAPICarsChargesDetails.go
@@ -42,9 +42,9 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 	}
 	// FastChargerInfo struct - child of ChargeDetails
 	type FastChargerInfo struct {
-		FastChargerPresent bool   `json:"fast_charger_present"` // bool
-		FastChargerBrand   string `json:"fast_charger_brand"`   // string
-		FastChargerType    string `json:"fast_charger_type"`    // string
+		FastChargerPresent bool       `json:"fast_charger_present"` // bool
+		FastChargerBrand   NullString `json:"fast_charger_brand"`   // string
+		FastChargerType    string     `json:"fast_charger_type"`    // string
 
 	}
 	// BatteryInfo struct - child of ChargeDetails
@@ -223,7 +223,7 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 				battery_heater_no_power,
 				conn_charge_cable,
 				fast_charger_present,
-				COALESCE(fast_charger_brand, '') AS fast_charger_brand,
+				fast_charger_brand,
 				fast_charger_type,
 				outside_temp
 			FROM charges

--- a/src/v1_TeslaMateAPICarsChargesDetails.go
+++ b/src/v1_TeslaMateAPICarsChargesDetails.go
@@ -223,7 +223,7 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 				battery_heater_no_power,
 				conn_charge_cable,
 				fast_charger_present,
-				COALESCE(fast_charger_brand, '') as fast_charger_brand
+				COALESCE(fast_charger_brand, '') AS fast_charger_brand,
 				fast_charger_type,
 				outside_temp
 			FROM charges

--- a/src/v1_TeslaMateAPICarsChargesDetails.go
+++ b/src/v1_TeslaMateAPICarsChargesDetails.go
@@ -223,7 +223,7 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 				battery_heater_no_power,
 				conn_charge_cable,
 				fast_charger_present,
-				fast_charger_brand,
+				COALESCE(fast_charger_brand, '') as fast_charger_brand
 				fast_charger_type,
 				outside_temp
 			FROM charges


### PR DESCRIPTION
Fatal error detected:
`sql: Scan error on column index 18, name "fast_charger_brand": converting NULL to string is unsupported`

Causes ChargeDetail API endpoint to fail. Solution was to add default string value for `fast_charger_brand`

Please test the SQL, I'm unsure how to run this patch.
