### PR TITLE
Update v1_TeslaMateAPICarsCharges.go

### DIFF
--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -84,7 +84,7 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 		SELECT
 			charging_processes.id AS charge_id,
 			start_date,
-			end_date,
+			COALESCE(end_date, '') AS end_date,
 			COALESCE(geofence.name, CONCAT_WS(', ', COALESCE(address.name, nullif(CONCAT_WS(' ', address.road, address.house_number), '')), address.city)) AS address,
 			COALESCE(charge_energy_added, 0) AS charge_energy_added,
 			COALESCE(charge_energy_used, 0) AS charge_energy_used,
@@ -162,7 +162,9 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 
 		// adjusting to timezone differences from UTC to be userspecific
 		charge.StartDate = getTimeInTimeZone(charge.StartDate)
-		charge.EndDate = getTimeInTimeZone(charge.EndDate)
+		if charge.EndDate != '' {
+			charge.EndDate = getTimeInTimeZone(charge.EndDate)
+		}
 
 		// checking for errors after scanning
 		if err != nil {


### PR DESCRIPTION
It's possible to have incomplete charges with missing EndDate. These aren't always valid objects either, but they shouldn't prevent the Charges endpoint from providing data.
I believe this can happen when TeslaMate is offline when the charging cycle ends. I am not sure if it's also possible if the vehicle is actively charging.

Feel free to edit this PR, not sure that an empty string is the best option.