### PR TITLE
Skip Malformed Rows (those missing an end_date)

### DIFF
--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -121,6 +121,11 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 
 	// looping through all results
 	for rows.Next() {
+		
+		// skip any malformed rows
+		if end_date == NULL {
+			continue
+		}
 
 		// creating charge object based on struct
 		charge := Charges{}


### PR DESCRIPTION
*Expected*
The Charges endpoint should still return data, even if a portion of charges have corrupted data.

*How it happens*
Charges can become corrupted if Teslamate does not detect that a charge ever ended, such as if the car or Teslamate goes offline when the charging ends.

*Note*
The charging_processes table's most recent row may be missing an end_date if the charge is in progress. These charges were already being skipped in the chargingDetails endpoint. I am assuming it is safe to skip them here, since they essentially have no data until the charge finishes.

*Please Test*
- Please test that this still builds as I am not entirely familiar with Go and am unsure how to test this on my docker container.