### PR TITLE
Prevent fatal error when detailed charge malformed

### DIFF
--- a/src/v1_TeslaMateAPICarsChargesDetails.go
+++ b/src/v1_TeslaMateAPICarsChargesDetails.go
@@ -150,6 +150,11 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 
 	// looping through all results
 	for rows.Next() {
+		
+		// skip a malformed charge
+ 		if end_date == NULL {
+ 			break
+ 		}
 
 		// creating charge object based on struct
 		charge := Charge{}


### PR DESCRIPTION
Following up on https://github.com/tobiasehlert/teslamateapi/issues/43

*Reason*
A detailed charge is malformed if the end_date is missing in SQL. It's also possible a charge that is in progress will be missing this value as well, in which case this detailed charge isn't populated with data.

*Better Solutions* (long term)
Adjust error handling across the API:
- *Opt 1:* Instead of `ValidResponse` being a boolean, replace with `ResponseError`. Change the if statement at the bottom of each file to check for the `ResponseError`'s existence instead of `if ValidResponse {...} else {...}`. Remove all log.Fatal(err) so that the API can still return responses gracefully, and set status to 200 OK since the response will still technically be HTTP valid. Break execution of further steps and return the meaningful ResponseError in the API
- *Opt 2:* For simplicity, create a functions like this and call it (along with an early `return`) wherever a fatal error is currently used (or `ValidResponse` never set to true). Then remove `ValidResponse` entirely and adjust the `if` statement at the bottom of every API file to only run the first condition.
```
func TeslaMateAPIHandleErrorResponse(c *gin.Context, s string) {
    log.Println("[error] TeslaMateAPICarsChargesDetailsV1 " + c.Request.RequestURI + " error in execution! " + s)
    c.JSON(http.StatusOK, gin.H{"error": s})
}
func TeslaMateAPIHandleSuccessResponse(c *gin.Context, j JSONData) {
    log.Println("[info] TeslaMateAPICarsChargesDetailsV1 " + c.Request.RequestURI + " executed successful.")
    c.JSON(http.StatusOK, j)
}
```

If you're interested, I'd be happy to put together a sample PR