### PR TITLE
Update Charges, Drives, and Updates API to Allow Empty Responses as Valid

### DIFF
--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -181,7 +181,7 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 	}
 	
 	// if no errors, but ChargeData is empty, return a valid response with an empty set
-	if len(ChargeData) == 0 {
+	if len(ChargesData) == 0 {
 		ValidResponse = true
 	}
 

--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -179,6 +179,11 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	
+	// if no errors, but ChargeData is empty, return a valid response with an empty set
+	if len(ChargeData) == 0 {
+		ValidResponse = true
+	}
 
 	//
 	// build the data-blob

--- a/src/v1_TeslaMateAPICarsDrives.go
+++ b/src/v1_TeslaMateAPICarsDrives.go
@@ -229,6 +229,11 @@ func TeslaMateAPICarsDrivesV1(c *gin.Context) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	
+	// if no errors, but DrivesData is empty, return a valid response with an empty set
+	if len(DrivesData) == 0 {
+		ValidResponse = true
+	}
 
 	//
 	// build the data-blob

--- a/src/v1_TeslaMateAPICarsUpdates.go
+++ b/src/v1_TeslaMateAPICarsUpdates.go
@@ -112,6 +112,11 @@ func TeslaMateAPICarsUpdatesV1(c *gin.Context) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	
+	// if no errors, but UpdatesData is empty, return a valid response with an empty set
+	if len(UpdatesData) == 0 {
+		ValidResponse = true
+	}
 
 	//
 	// build the data-blob


### PR DESCRIPTION
API should fail gracefully if an empty response is sent. This was completed against Charges, Drives, and Updates API endpoints.

Example reason: an API consumer should be able to traverse the pages until empty data is returned.

Note: A generic error will be thrown if the data set is empty (including on a fresh install of TeslaMate) or if there is an invalid charge in the response (in the case of charges). Therefore, it's impossible to know if all data points were traversed or if an error exists on a single object in the array (See: #43 for Charges bug)