### PR TITLE
PoC of response handler

### DIFF
--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -210,8 +210,8 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 
 	// return jsonData
 	if ValidResponse {
-		TeslaMateAPIHandleSuccessResponse(c, jsonData)
+		TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPICarsChargesV1", jsonData)
 	} else {
-		TeslaMateAPIHandleErrorResponse(c, "something went wrong in TeslaMateAPICarsChargesV1..")
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesV1", "something went wrong")
 	}
 }

--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -210,10 +210,8 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 
 	// return jsonData
 	if ValidResponse {
-		log.Println("[info] TeslaMateAPICarsChargesV1 " + c.Request.RequestURI + " executed successful.")
-		c.JSON(http.StatusOK, jsonData)
+		TeslaMateAPIHandleSuccessResponse(c, jsonData)
 	} else {
-		log.Println("[error] TeslaMateAPICarsChargesV1 " + c.Request.RequestURI + " error in execution!")
-		c.JSON(http.StatusNotFound, gin.H{"error": "something went wrong in TeslaMateAPICarsChargesV1.."})
+		TeslaMateAPIHandleErrorResponse(c, "something went wrong in TeslaMateAPICarsChargesV1..")
 	}
 }

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -179,13 +179,13 @@ func initDBconnection() {
 	}
 }
 
-func TeslaMateAPIHandleErrorResponse(c *gin.Context, s string) {
-    log.Println("[error] TeslaMateAPICarsChargesDetailsV1 " + c.Request.RequestURI + " error in execution! " + s)
-    c.JSON(http.StatusOK, gin.H{"error": s})
+func TeslaMateAPIHandleErrorResponse(c *gin.Context, s1 string, s2 string) {
+    log.Println("[error] " + s1 + " - " + c.Request.RequestURI + " error in execution! " + s2)
+    c.JSON(http.StatusOK, gin.H{"error": s2})
 }
 
-func TeslaMateAPIHandleSuccessResponse(c *gin.Context, j JSONData) {
-    log.Println("[info] TeslaMateAPICarsChargesDetailsV1 " + c.Request.RequestURI + " executed successful.")
+func TeslaMateAPIHandleSuccessResponse(c *gin.Context, s string, j JSONData) {
+    log.Println("[info] " + s + " - " + c.Request.RequestURI + " executed successful.")
     c.JSON(http.StatusOK, j)
 }
 

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -179,6 +179,16 @@ func initDBconnection() {
 	}
 }
 
+func TeslaMateAPIHandleErrorResponse(c *gin.Context, s string) {
+    log.Println("[error] TeslaMateAPICarsChargesDetailsV1 " + c.Request.RequestURI + " error in execution! " + s)
+    c.JSON(http.StatusOK, gin.H{"error": s})
+}
+
+func TeslaMateAPIHandleSuccessResponse(c *gin.Context, j JSONData) {
+    log.Println("[info] TeslaMateAPICarsChargesDetailsV1 " + c.Request.RequestURI + " executed successful.")
+    c.JSON(http.StatusOK, j)
+}
+
 func getTimeInTimeZone(datestring string) string {
 
 	// getting timezone from environment


### PR DESCRIPTION
Only added surface level implementation to one place as a proof of concept. Theoretically, we would sprinkle `TeslaMateAPIHandleErrorResponse` across the endpoint files instead of waiting until the end. Then we can forget `ValidResponse` entirely, and know that it is successful if we reach the bottom.

The final goal here it to remove instances of log.Fatal(err) where the app can no longer handle an error response. When it crashes, the connection is dropped and the user isn't provided an error. This lays the foundation to fix it.

----

This is not ready for a merge, but I want to get discussion about it going. It's a proof of concept. Also I don't have enough time tonight to put together a 100% implementation.