### PR TITLE
Display incomplete charge data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 .env
+.DS_Store

--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -182,8 +182,8 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 				new(sql.RawBytes), // UnitsTemperature
 				new(sql.RawBytes), // CarName
 			}
-			var err2 error
-			err2 = rows.Scan(dest...)
+
+			var err2 error = rows.Scan(dest...)
 
 			if dest[0] != nil {
 				if err2 != nil {

--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -158,7 +158,7 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 		
 		// creating incomplete charge object based on struct
 		// incomplete charges may still be in progress, or a previous charge that failed to complete
-  		if charge.EndDate == NULL {
+  		if charge.EndDate == nil {
 			incompleteCharge := IncompleteCharges{
 				ChargeID: charge.ChargeID, 
 				StartDate: charge.StartDate,

--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -129,31 +129,6 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 
 	// looping through all results
 	for rows.Next() {
-		
-		// creating incomplete charge object based on struct
-		// incomplete charges may still be in progress, or a previous charge that failed to complete
-  		if end_date == NULL {
-			incompleteCharge := IncompleteCharges{}
-			
-			err = rows.Scan (
-				&incompleteCharge.ChargeID,
-				&incompleteCharge.StartDate,
-				&incompleteCharge.Address,
-			)
-			
-			// adjusting to timezone differences from UTC to be userspecific
-			incompleteCharge.StartDate = getTimeInTimeZone(incompleteCharge.StartDate)
-			
-			// checking for errors after scanning
-			if err != nil {
-				log.Fatal(err)
-			}
-			
-			// appending charge to ChargesData
-			IncompleteChargesData = append(IncompleteChargesData, incompleteCharge)
-			
-  			break
-  		}
 
 		// creating charge object based on struct
 		charge := Charges{}
@@ -180,6 +155,24 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 			&UnitsTemperature,
 			&CarName,
 		)
+		
+		// creating incomplete charge object based on struct
+		// incomplete charges may still be in progress, or a previous charge that failed to complete
+  		if charge.EndDate == NULL {
+			incompleteCharge := IncompleteCharges{
+				ChargeID: charge.ChargeID, 
+				StartDate: charge.StartDate,
+				Address: charge.Address,
+			}
+			
+			// adjusting to timezone differences from UTC to be userspecific
+			incompleteCharge.StartDate = getTimeInTimeZone(incompleteCharge.StartDate)
+			
+			// appending charge to ChargesData
+			IncompleteChargesData = append(IncompleteChargesData, incompleteCharge)
+			
+  			break
+  		}
 
 		// converting values based of settings UnitsLength
 		if UnitsLength == "mi" {

--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"database/sql"
 
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
@@ -64,8 +65,8 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 	// Data struct - child of JSONData
 	type Data struct {
 		Car                Car                    `json:"car"`
-		Charges            []Charges              `json:"charges"`
 		IncompleteCharges  []IncompleteCharges    `json:"incomplete_charges"`
+		Charges            []Charges              `json:"charges"`
 		TeslaMateUnits     TeslaMateUnits         `json:"units"`
 	}
 	// JSONData struct - main
@@ -181,6 +182,7 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 				new(sql.RawBytes), // UnitsTemperature
 				new(sql.RawBytes), // CarName
 			}
+			var err2 error
 			err2 = rows.Scan(dest...)
 			
 			if dest[0] != nil {
@@ -188,11 +190,10 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 					log.Fatal(err2)
 				}
 				// There is a charge available, it's just incomplete
-				incompleteCharge := IncompleteCharges{
-					ChargeID: dest[0], 
-					StartDate: dest[1],
-					Address: dest[3],
-				}
+				incompleteCharge := IncompleteCharges{}
+				incompleteCharge.ChargeID = *(dest)[0].(*int)
+				incompleteCharge.StartDate = *(dest)[1].(*string)
+				incompleteCharge.Address = *(dest)[3].(*string)
 			
 				// adjusting to timezone differences from UTC to be userspecific
 				incompleteCharge.StartDate = getTimeInTimeZone(incompleteCharge.StartDate)
@@ -247,8 +248,8 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 				CarID:   CarID,
 				CarName: CarName,
 			},
-			Charges: ChargesData,
 			IncompleteCharges: IncompleteChargesData,
+			Charges: ChargesData,
 			TeslaMateUnits: TeslaMateUnits{
 				UnitsLength:      UnitsLength,
 				UnitsTemperature: UnitsTemperature,

--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"database/sql"
 	"encoding/json"
 	"log"
 	"net/http"
-	"database/sql"
 
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
@@ -53,9 +53,9 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 	}
 	// Incomplete Charges struct - child of Data
 	type IncompleteCharges struct {
-		ChargeID          int            `json:"charge_id"`           // int
-		StartDate         string         `json:"start_date"`          // string
-		Address           string         `json:"address"`             // string
+		ChargeID  int    `json:"charge_id"`  // int
+		StartDate string `json:"start_date"` // string
+		Address   string `json:"address"`    // string
 	}
 	// TeslaMateUnits struct - child of Data
 	type TeslaMateUnits struct {
@@ -64,10 +64,10 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 	}
 	// Data struct - child of JSONData
 	type Data struct {
-		Car                Car                    `json:"car"`
-		IncompleteCharges  []IncompleteCharges    `json:"incomplete_charges"`
-		Charges            []Charges              `json:"charges"`
-		TeslaMateUnits     TeslaMateUnits         `json:"units"`
+		Car               Car                 `json:"car"`
+		IncompleteCharges []IncompleteCharges `json:"incomplete_charges"`
+		Charges           []Charges           `json:"charges"`
+		TeslaMateUnits    TeslaMateUnits      `json:"units"`
 	}
 	// JSONData struct - main
 	type JSONData struct {
@@ -156,16 +156,16 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 			&UnitsTemperature,
 			&CarName,
 		)
-		
+
 		// checking for errors after scanning
 		// Incomplete charges may still be in progress, or a previous charge that failed to finalize
 		if err != nil {
 			// Check if charge is available with incomplete data
 			dest := []interface{}{ // Standard MySQL columns
-				new(int), // ChargeID
-				new(string), // StartDate
+				new(int),          // ChargeID
+				new(string),       // StartDate
 				new(sql.RawBytes), // EndDate
-				new(string), // Address
+				new(string),       // Address
 				new(sql.RawBytes), // ChargeEnergyAdded
 				new(sql.RawBytes), // ChargeEnergyUsed
 				new(sql.RawBytes), // Cost
@@ -184,7 +184,7 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 			}
 			var err2 error
 			err2 = rows.Scan(dest...)
-			
+
 			if dest[0] != nil {
 				if err2 != nil {
 					log.Fatal(err2)
@@ -194,7 +194,7 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 				incompleteCharge.ChargeID = *(dest)[0].(*int)
 				incompleteCharge.StartDate = *(dest)[1].(*string)
 				incompleteCharge.Address = *(dest)[3].(*string)
-			
+
 				// adjusting to timezone differences from UTC to be userspecific
 				incompleteCharge.StartDate = getTimeInTimeZone(incompleteCharge.StartDate)
 
@@ -202,7 +202,7 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 				IncompleteChargesData = append(IncompleteChargesData, incompleteCharge)
 
 				continue
-				
+
 			} else {
 				log.Fatal(err)
 			}
@@ -234,7 +234,7 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	
+
 	// if no errors, but ChargeData is empty, return a valid response with an empty set
 	if len(ChargesData) == 0 {
 		ValidResponse = true
@@ -249,7 +249,7 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 				CarName: CarName,
 			},
 			IncompleteCharges: IncompleteChargesData,
-			Charges: ChargesData,
+			Charges:           ChargesData,
 			TeslaMateUnits: TeslaMateUnits{
 				UnitsLength:      UnitsLength,
 				UnitsTemperature: UnitsTemperature,

--- a/src/v1_TeslaMateAPICarsChargesDetails.go
+++ b/src/v1_TeslaMateAPICarsChargesDetails.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
-	"database/sql"
 
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
@@ -87,13 +86,6 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 		OutsideTempAvg    float64         `json:"outside_temp_avg"`    // float64
 		ChargeDetails     []ChargeDetails `json:"charge_details"`      // struct
 	}
-	// Incomplete Charges struct - child of Data
-	type IncompleteCharge struct {
-		ChargeID          int                `json:"charge_id"`           // int
-		StartDate         string             `json:"start_date"`          // string
-		Address           string             `json:"address"`             // string
-		ChargeDetails     []ChargeDetails    `json:"charge_details"`      // struct
-	}
 	// TeslaMateUnits struct - child of Data
 	type TeslaMateUnits struct {
 		UnitsLength      string `json:"unit_of_length"`      // string
@@ -101,10 +93,9 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 	}
 	// Data struct - child of JSONData
 	type Data struct {
-		Car                Car                `json:"car"`
-		Charge             Charge             `json:"charge"`
-		IncompleteCharge   IncompleteCharge   `json:"incomplete_charge"`
-		TeslaMateUnits     TeslaMateUnits     `json:"units"`
+		Car            Car            `json:"car"`
+		Charge         Charge         `json:"charge"`
+		TeslaMateUnits TeslaMateUnits `json:"units"`
 	}
 	// JSONData struct - main
 	type JSONData struct {
@@ -113,7 +104,6 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 
 	// creating required vars
 	var ChargeData Charge
-	var IncompleteChargeData IncompleteCharge
 	var ChargeDetailsData []ChargeDetails
 	var UnitsLength, UnitsTemperature, CarName string
 	var ValidResponse bool // default is false

--- a/src/v1_TeslaMateAPICarsChargesDetails.go
+++ b/src/v1_TeslaMateAPICarsChargesDetails.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"database/sql"
 
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
@@ -86,6 +87,13 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 		OutsideTempAvg    float64         `json:"outside_temp_avg"`    // float64
 		ChargeDetails     []ChargeDetails `json:"charge_details"`      // struct
 	}
+	// Incomplete Charges struct - child of Data
+	type IncompleteCharge struct {
+		ChargeID          int                `json:"charge_id"`           // int
+		StartDate         string             `json:"start_date"`          // string
+		Address           string             `json:"address"`             // string
+		ChargeDetails     []ChargeDetails    `json:"charge_details"`      // struct
+	}
 	// TeslaMateUnits struct - child of Data
 	type TeslaMateUnits struct {
 		UnitsLength      string `json:"unit_of_length"`      // string
@@ -93,9 +101,10 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 	}
 	// Data struct - child of JSONData
 	type Data struct {
-		Car            Car            `json:"car"`
-		Charge         Charge         `json:"charge"`
-		TeslaMateUnits TeslaMateUnits `json:"units"`
+		Car                Car                `json:"car"`
+		Charge             Charge             `json:"charge"`
+		IncompleteCharge   IncompleteCharge   `json:"incomplete_charge"`
+		TeslaMateUnits     TeslaMateUnits     `json:"units"`
 	}
 	// JSONData struct - main
 	type JSONData struct {
@@ -104,6 +113,7 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 
 	// creating required vars
 	var ChargeData Charge
+	var IncompleteChargeData IncompleteCharge
 	var ChargeDetailsData []ChargeDetails
 	var UnitsLength, UnitsTemperature, CarName string
 	var ValidResponse bool // default is false

--- a/src/v1_TeslaMateAPICarsChargesDetails.go
+++ b/src/v1_TeslaMateAPICarsChargesDetails.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"database/sql"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -86,6 +87,13 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 		OutsideTempAvg    float64         `json:"outside_temp_avg"`    // float64
 		ChargeDetails     []ChargeDetails `json:"charge_details"`      // struct
 	}
+	// Incomplete charge struct - child of Data
+	type IncompleteCharge struct {
+		ChargeID      int             `json:"charge_id"`      // int
+		StartDate     string          `json:"start_date"`     // string
+		Address       string          `json:"address"`        // string
+		ChargeDetails []ChargeDetails `json:"charge_details"` // struct
+	}
 	// TeslaMateUnits struct - child of Data
 	type TeslaMateUnits struct {
 		UnitsLength      string `json:"unit_of_length"`      // string
@@ -93,9 +101,11 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 	}
 	// Data struct - child of JSONData
 	type Data struct {
-		Car            Car            `json:"car"`
-		Charge         Charge         `json:"charge"`
-		TeslaMateUnits TeslaMateUnits `json:"units"`
+		Car               Car               `json:"car"`
+		IsChargeCompleted bool              `json:"is_charge_completed"`
+		IncompleteCharge  *IncompleteCharge `json:"incomplete_charge,omitempty"`
+		Charge            *Charge           `json:"charge,omitempty"`
+		TeslaMateUnits    TeslaMateUnits    `json:"units"`
 	}
 	// JSONData struct - main
 	type JSONData struct {
@@ -104,7 +114,9 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 
 	// creating required vars
 	var ChargeData Charge
+	var IncompleteChargeData IncompleteCharge
 	var ChargeDetailsData []ChargeDetails
+	var IsChargeCompleted bool = true
 	var UnitsLength, UnitsTemperature, CarName string
 	var ValidResponse bool // default is false
 
@@ -136,7 +148,7 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 		LEFT JOIN positions position ON position_id = position.id
 		LEFT JOIN geofences geofence ON geofence_id = geofence.id
 		LEFT JOIN charges ON charging_processes.id = charges.id
-		WHERE charging_processes.car_id=$1 AND charging_processes.id=$2 AND charging_processes.end_date IS NOT NULL
+		WHERE charging_processes.car_id=$1 AND charging_processes.id=$2
 		ORDER BY start_date DESC;`
 	rows, err := db.Query(query, CarID, ChargeID)
 
@@ -177,30 +189,78 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 			&CarName,
 		)
 
-		// converting values based of settings UnitsLength
-		if UnitsLength == "mi" {
-			charge.RangeIdeal.StartRange = kilometersToMiles(charge.RangeIdeal.StartRange)
-			charge.RangeIdeal.EndRange = kilometersToMiles(charge.RangeIdeal.EndRange)
-			charge.RangeRated.StartRange = kilometersToMiles(charge.RangeRated.StartRange)
-			charge.RangeRated.EndRange = kilometersToMiles(charge.RangeRated.EndRange)
-		}
-		// converting values based of settings UnitsTemperature
-		if UnitsTemperature == "F" {
-			charge.OutsideTempAvg = celsiusToFahrenheit(charge.OutsideTempAvg)
-		}
-
-		// adjusting to timezone differences from UTC to be userspecific
-		charge.StartDate = getTimeInTimeZone(charge.StartDate)
-		charge.EndDate = getTimeInTimeZone(charge.EndDate)
-
 		// checking for errors after scanning
+		// Incomplete charges may still be in progress, or a previous charge that failed to finalize
 		if err != nil {
-			log.Fatal(err)
-		}
+			// Check if charge is available with incomplete data
+			dest := []interface{}{ // Standard MySQL columns
+				new(int),          // ChargeID
+				new(string),       // StartDate
+				new(sql.RawBytes), // EndDate
+				new(string),       // Address
+				new(sql.RawBytes), // ChargeEnergyAdded
+				new(sql.RawBytes), // ChargeEnergyUsed
+				new(sql.RawBytes), // Cost
+				new(sql.RawBytes), // StartRange
+				new(sql.RawBytes), // EndRange
+				new(sql.RawBytes), // StartRange
+				new(sql.RawBytes), // EndRange
+				new(sql.RawBytes), // StartBatteryLevel
+				new(sql.RawBytes), // EndBatteryLevel
+				new(sql.RawBytes), // DurationMin
+				new(sql.RawBytes), // DurationStr
+				new(sql.RawBytes), // OutsideTempAvg
+				new(sql.RawBytes), // UnitsLength
+				new(sql.RawBytes), // UnitsTemperature
+				new(sql.RawBytes), // CarName
+			}
 
-		// appending charge to ChargeData
-		ChargeData = charge
-		ValidResponse = true
+			var err2 error = rows.Scan(dest...)
+
+			if dest[0] != nil {
+				IsChargeCompleted = false
+
+				if err2 != nil {
+					log.Fatal(err2)
+				}
+				// There is a charge available, it's just incomplete
+				incompleteCharge := IncompleteCharge{}
+				incompleteCharge.ChargeID = *(dest)[0].(*int)
+				incompleteCharge.StartDate = *(dest)[1].(*string)
+				incompleteCharge.Address = *(dest)[3].(*string)
+
+				// adjusting to timezone differences from UTC to be userspecific
+				incompleteCharge.StartDate = getTimeInTimeZone(incompleteCharge.StartDate)
+
+				// appending charge to ChargesData
+				IncompleteChargeData = incompleteCharge
+
+				ValidResponse = true
+			} else {
+				log.Fatal(err)
+			}
+		} else {
+			// converting values based of settings UnitsLength
+			if UnitsLength == "mi" {
+				charge.RangeIdeal.StartRange = kilometersToMiles(charge.RangeIdeal.StartRange)
+				charge.RangeIdeal.EndRange = kilometersToMiles(charge.RangeIdeal.EndRange)
+				charge.RangeRated.StartRange = kilometersToMiles(charge.RangeRated.StartRange)
+				charge.RangeRated.EndRange = kilometersToMiles(charge.RangeRated.EndRange)
+			}
+			// converting values based of settings UnitsTemperature
+			if UnitsTemperature == "F" {
+				charge.OutsideTempAvg = celsiusToFahrenheit(charge.OutsideTempAvg)
+			}
+
+			// adjusting to timezone differences from UTC to be userspecific
+			charge.StartDate = getTimeInTimeZone(charge.StartDate)
+			charge.EndDate = getTimeInTimeZone(charge.EndDate)
+
+			// appending charge to ChargeData
+			ChargeData = charge
+
+			ValidResponse = true
+		}
 
 		// getting detailed charge data from database
 		query = `
@@ -290,7 +350,12 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 
 			// appending drive to ChargeData
 			ChargeDetailsData = append(ChargeDetailsData, chargedetails)
+		}
+
+		if IsChargeCompleted {
 			ChargeData.ChargeDetails = ChargeDetailsData
+		} else {
+			IncompleteChargeData.ChargeDetails = ChargeDetailsData
 		}
 	}
 
@@ -308,12 +373,18 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 				CarID:   CarID,
 				CarName: CarName,
 			},
-			Charge: ChargeData,
+			IsChargeCompleted: IsChargeCompleted,
 			TeslaMateUnits: TeslaMateUnits{
 				UnitsLength:      UnitsLength,
 				UnitsTemperature: UnitsTemperature,
 			},
 		},
+	}
+
+	if IsChargeCompleted {
+		jsonData.Data.Charge = &ChargeData
+	} else {
+		jsonData.Data.IncompleteCharge = &IncompleteChargeData
 	}
 
 	// print to log about request


### PR DESCRIPTION
While these are usually charges that failed, they also include charges that are in progress. The client should be able to see these Charges and decide how to proceed. These charges were, at one point, real charges with relevant data.

Reasons for failure:
- Charging started, TeslaMate server or Tesla API went offline
- Charging in progress (not actually failure, just incomplete charge data)

This will also allow the user to know about the charge's existence and query (by ID) the Charge Details. Since the database stored the many charge detail objects, the user may be able to process some additional information about the charge. Especially if the charge is in progress.

Example:
1. Charge is in progress.
2. Receive basic charge data, like start date and charge ID. 
3. Query Charge Details to info like: start date, power over time, etc.

However, even with access to this additional data that does exist, the user still will not be able to see data from when the charge went offline. Or in the case the charge is still occurring, the user can't see charge details that haven't happened yet.

Therefore,
Charge Details require an additional parameter `IsChargeCompleted bool` so the user knows if an object is finalized.

**The user will have to determine whether the charge is still in progress or corrupted, by seeing if there are any recent charges. If it's in progress, the user should consider refreshing that charge object in the future.**

I chose to add this as a separate object on `Data` so that it will not affect existing API users. This will ensure incomplete charges are not treated as completed charges.
