### PR TITLE
Feature: response handler

### DIFF
--- a/src/v1_TeslaMateAPICars.go
+++ b/src/v1_TeslaMateAPICars.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
 )
@@ -179,6 +177,6 @@ func TeslaMateAPICarsV1(c *gin.Context) {
 	}
 
 	// return jsonData
-	TeslaMateAPIHandleSuccessResponse(c, http.StatusOK, "TeslaMateAPICarsV1", jsonData)
+	TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPICarsV1", jsonData)
 
 }

--- a/src/v1_TeslaMateAPICars.go
+++ b/src/v1_TeslaMateAPICars.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
 )
@@ -174,6 +176,6 @@ func TeslaMateAPICarsV1(c *gin.Context) {
 	}
 
 	// return jsonData
-	TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPICarsV1", jsonData)
+	TeslaMateAPIHandleSuccessResponse(c, http.StatusOK, "TeslaMateAPICarsV1", jsonData)
 
 }

--- a/src/v1_TeslaMateAPICars.go
+++ b/src/v1_TeslaMateAPICars.go
@@ -7,10 +7,11 @@ import (
 	_ "github.com/lib/pq"
 )
 
-const CarsError1 = "Unable to load cars."
-
 // TeslaMateAPICarsV1 func
 func TeslaMateAPICarsV1(c *gin.Context) {
+
+	// define error messages
+	var CarsError1 = "Unable to load cars."
 
 	// getting CarID param from URL
 	ParamCarID := c.Param("CarID")

--- a/src/v1_TeslaMateAPICars.go
+++ b/src/v1_TeslaMateAPICars.go
@@ -7,6 +7,8 @@ import (
 	_ "github.com/lib/pq"
 )
 
+const CarsError1 = "Unable to load cars."
+
 // TeslaMateAPICarsV1 func
 func TeslaMateAPICarsV1(c *gin.Context) {
 
@@ -105,7 +107,7 @@ func TeslaMateAPICarsV1(c *gin.Context) {
 
 	// checking for errors in query
 	if err != nil {
-		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsV1", "Unable to load cars.", err.Error())
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsV1", CarsError1, err.Error())
 		return
 	}
 
@@ -145,7 +147,7 @@ func TeslaMateAPICarsV1(c *gin.Context) {
 
 		// checking for errors after scanning
 		if err != nil {
-			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsV1", "Unable to load cars.", err.Error())
+			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsV1", CarsError1, err.Error())
 			return
 		}
 
@@ -163,7 +165,7 @@ func TeslaMateAPICarsV1(c *gin.Context) {
 	// checking for errors in the rows result
 	err = rows.Err()
 	if err != nil {
-		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsV1", "Unable to load cars.", err.Error())
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsV1", CarsError1, err.Error())
 		return
 	}
 

--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -210,8 +210,8 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 
 	// return jsonData
 	if ValidResponse {
-		TeslaMateAPIHandleSuccessResponse(c, jsonData)
+		TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPICarsChargesV1", jsonData)
 	} else {
-		TeslaMateAPIHandleErrorResponse(c, "something went wrong in TeslaMateAPICarsChargesV1..")
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesV1", "something went wrong")
 	}
 }

--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
 )
@@ -199,5 +197,5 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 	}
 
 	// return jsonData
-	TeslaMateAPIHandleSuccessResponse(c, http.StatusOK, "TeslaMateAPICarsChargesV1", jsonData)
+	TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPICarsChargesV1", jsonData)
 }

--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -7,6 +7,8 @@ import (
 	_ "github.com/lib/pq"
 )
 
+const CarsChargesError1 = "Unable to load charges."
+
 // TeslaMateAPICarsChargesV1 func
 func TeslaMateAPICarsChargesV1(c *gin.Context) {
 
@@ -110,7 +112,7 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 
 	// checking for errors in query
 	if err != nil {
-		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesV1", "Unable to load charges.", err.Error())
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesV1", CarsChargesError1, err.Error())
 		return
 	}
 
@@ -164,7 +166,7 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 
 		// checking for errors after scanning
 		if err != nil {
-			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesV1", "Unable to load charges.", err.Error())
+			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesV1", CarsChargesError1, err.Error())
 			return
 		}
 
@@ -175,7 +177,7 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 	// checking for errors in the rows result
 	err = rows.Err()
 	if err != nil {
-		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesV1", "Unable to load charges.", err.Error())
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesV1", CarsChargesError1, err.Error())
 		return
 	}
 

--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -1,10 +1,6 @@
 package main
 
 import (
-	"encoding/json"
-	"log"
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
 )

--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -210,10 +210,8 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 
 	// return jsonData
 	if ValidResponse {
-		log.Println("[info] TeslaMateAPICarsChargesV1 " + c.Request.RequestURI + " executed successful.")
-		c.JSON(http.StatusOK, jsonData)
+		TeslaMateAPIHandleSuccessResponse(c, jsonData)
 	} else {
-		log.Println("[error] TeslaMateAPICarsChargesV1 " + c.Request.RequestURI + " error in execution!")
-		c.JSON(http.StatusNotFound, gin.H{"error": "something went wrong in TeslaMateAPICarsChargesV1.."})
+		TeslaMateAPIHandleErrorResponse(c, "something went wrong in TeslaMateAPICarsChargesV1..")
 	}
 }

--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -7,10 +7,11 @@ import (
 	_ "github.com/lib/pq"
 )
 
-const CarsChargesError1 = "Unable to load charges."
-
 // TeslaMateAPICarsChargesV1 func
 func TeslaMateAPICarsChargesV1(c *gin.Context) {
+
+	// define error messages
+	var CarsChargesError1 = "Unable to load charges."
 
 	// getting CarID param from URL
 	CarID := convertStringToInteger(c.Param("CarID"))

--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
 )
@@ -194,5 +196,5 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 	}
 
 	// return jsonData
-	TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPICarsChargesV1", jsonData)
+	TeslaMateAPIHandleSuccessResponse(c, http.StatusOK, "TeslaMateAPICarsChargesV1", jsonData)
 }

--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -108,14 +108,14 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 		LIMIT $2 OFFSET $3;`
 	rows, err := db.Query(query, CarID, ResultShow, ResultPage)
 
-	// defer closing rows
-	defer rows.Close()
-
 	// checking for errors in query
 	if err != nil {
 		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesV1", "Unable to load charges.", err.Error())
 		return
 	}
+
+	// defer closing rows
+	defer rows.Close()
 
 	// looping through all results
 	for rows.Next() {

--- a/src/v1_TeslaMateAPICarsChargesDetails.go
+++ b/src/v1_TeslaMateAPICarsChargesDetails.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
 )
@@ -316,5 +318,5 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 	}
 
 	// return jsonData
-	TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPICarsChargesDetailsV1", jsonData)
+	TeslaMateAPIHandleSuccessResponse(c, http.StatusOK, "TeslaMateAPICarsChargesDetailsV1", jsonData)
 }

--- a/src/v1_TeslaMateAPICarsChargesDetails.go
+++ b/src/v1_TeslaMateAPICarsChargesDetails.go
@@ -137,14 +137,14 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 		ORDER BY start_date DESC;`
 	rows, err := db.Query(query, CarID, ChargeID)
 
-	// defer closing rows
-	defer rows.Close()
-
 	// checking for errors in query
 	if err != nil {
 		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesDetailsV1", "Unable to load charge.", err.Error())
 		return
 	}
+
+	// defer closing rows
+	defer rows.Close()
 
 	// looping through all results
 	for rows.Next() {
@@ -229,14 +229,14 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 			ORDER BY id ASC;`
 		rows, err = db.Query(query, ChargeID)
 
-		// defer closing rows
-		defer rows.Close()
-
 		// checking for errors in query
 		if err != nil {
 			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesDetailsV1", "Unable to load charge details.", err.Error())
 			return
 		}
+
+		// defer closing rows
+		defer rows.Close()
 
 		// looping through all results
 		for rows.Next() {

--- a/src/v1_TeslaMateAPICarsChargesDetails.go
+++ b/src/v1_TeslaMateAPICarsChargesDetails.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
 )
@@ -322,5 +320,5 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 	}
 
 	// return jsonData
-	TeslaMateAPIHandleSuccessResponse(c, http.StatusOK, "TeslaMateAPICarsChargesDetailsV1", jsonData)
+	TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPICarsChargesDetailsV1", jsonData)
 }

--- a/src/v1_TeslaMateAPICarsChargesDetails.go
+++ b/src/v1_TeslaMateAPICarsChargesDetails.go
@@ -7,6 +7,9 @@ import (
 	_ "github.com/lib/pq"
 )
 
+const CarsChargesDetailsError1 = "Unable to load charge."
+const CarsChargesDetailsError2 = "Unable to load charge details."
+
 // TeslaMateAPICarsChargesDetailsV1 func
 func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 
@@ -139,7 +142,7 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 
 	// checking for errors in query
 	if err != nil {
-		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesDetailsV1", "Unable to load charge.", err.Error())
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesDetailsV1", CarsChargesDetailsError1, err.Error())
 		return
 	}
 
@@ -193,7 +196,7 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 
 		// checking for errors after scanning
 		if err != nil {
-			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesDetailsV1", "Unable to load charge.", err.Error())
+			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesDetailsV1", CarsChargesDetailsError1, err.Error())
 			return
 		}
 
@@ -231,7 +234,7 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 
 		// checking for errors in query
 		if err != nil {
-			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesDetailsV1", "Unable to load charge details.", err.Error())
+			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesDetailsV1", CarsChargesDetailsError2, err.Error())
 			return
 		}
 
@@ -284,7 +287,7 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 
 			// checking for errors after scanning
 			if err != nil {
-				TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesDetailsV1", "Unable to load charge details.", err.Error())
+				TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesDetailsV1", CarsChargesDetailsError2, err.Error())
 				return
 			}
 
@@ -297,7 +300,7 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 	// checking for errors in the rows result
 	err = rows.Err()
 	if err != nil {
-		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesDetailsV1", "Unable to load charge details.", err.Error())
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesDetailsV1", CarsChargesDetailsError2, err.Error())
 		return
 	}
 

--- a/src/v1_TeslaMateAPICarsChargesDetails.go
+++ b/src/v1_TeslaMateAPICarsChargesDetails.go
@@ -1,10 +1,6 @@
 package main
 
 import (
-	"encoding/json"
-	"log"
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
 )
@@ -106,7 +102,6 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 	var ChargeData Charge
 	var ChargeDetailsData []ChargeDetails
 	var UnitsLength, UnitsTemperature, CarName string
-	var ValidResponse bool // default is false
 
 	// getting data from database
 	query := `
@@ -140,13 +135,14 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 		ORDER BY start_date DESC;`
 	rows, err := db.Query(query, CarID, ChargeID)
 
-	// checking for errors in query
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	// defer closing rows
 	defer rows.Close()
+
+	// checking for errors in query
+	if err != nil {
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesDetailsV1", "Unable to load charge.", err.Error())
+		return
+	}
 
 	// looping through all results
 	for rows.Next() {
@@ -195,12 +191,12 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 
 		// checking for errors after scanning
 		if err != nil {
-			log.Fatal(err)
+			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesDetailsV1", "Unable to load charge.", err.Error())
+			return
 		}
 
 		// appending charge to ChargeData
 		ChargeData = charge
-		ValidResponse = true
 
 		// getting detailed charge data from database
 		query = `
@@ -231,13 +227,14 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 			ORDER BY id ASC;`
 		rows, err = db.Query(query, ChargeID)
 
-		// checking for errors in query
-		if err != nil {
-			log.Fatal(err)
-		}
-
 		// defer closing rows
 		defer rows.Close()
+
+		// checking for errors in query
+		if err != nil {
+			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesDetailsV1", "Unable to load charge details.", err.Error())
+			return
+		}
 
 		// looping through all results
 		for rows.Next() {
@@ -285,7 +282,8 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 
 			// checking for errors after scanning
 			if err != nil {
-				log.Fatal(err)
+				TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesDetailsV1", "Unable to load charge details.", err.Error())
+				return
 			}
 
 			// appending drive to ChargeData
@@ -297,7 +295,8 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 	// checking for errors in the rows result
 	err = rows.Err()
 	if err != nil {
-		log.Fatal(err)
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesDetailsV1", "Unable to load charge details.", err.Error())
+		return
 	}
 
 	//
@@ -316,19 +315,6 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 		},
 	}
 
-	// print to log about request
-	if gin.IsDebugging() {
-		log.Println("[debug] TeslaMateAPICarsChargesDetailsV1 " + c.Request.RequestURI + " returned data:")
-		js, _ := json.Marshal(jsonData)
-		log.Printf("[debug] %s\n", js)
-	}
-
 	// return jsonData
-	if ValidResponse {
-		log.Println("[info] TeslaMateAPICarsChargesDetailsV1 " + c.Request.RequestURI + " executed successful.")
-		c.JSON(http.StatusOK, jsonData)
-	} else {
-		log.Println("[error] TeslaMateAPICarsChargesDetailsV1 " + c.Request.RequestURI + " error in execution!")
-		c.JSON(http.StatusNotFound, gin.H{"error": "something went wrong in TeslaMateAPICarsChargesDetailsV1.."})
-	}
+	TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPICarsChargesDetailsV1", jsonData)
 }

--- a/src/v1_TeslaMateAPICarsChargesDetails.go
+++ b/src/v1_TeslaMateAPICarsChargesDetails.go
@@ -7,11 +7,12 @@ import (
 	_ "github.com/lib/pq"
 )
 
-const CarsChargesDetailsError1 = "Unable to load charge."
-const CarsChargesDetailsError2 = "Unable to load charge details."
-
 // TeslaMateAPICarsChargesDetailsV1 func
 func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
+
+	// define error messages
+	var CarsChargesDetailsError1 = "Unable to load charge."
+	var CarsChargesDetailsError2 = "Unable to load charge details."
 
 	// getting CarID and ChargeID param from URL
 	CarID := convertStringToInteger(c.Param("CarID"))

--- a/src/v1_TeslaMateAPICarsCommand.go
+++ b/src/v1_TeslaMateAPICarsCommand.go
@@ -51,7 +51,7 @@ func TeslaMateAPICarsCommandV1(c *gin.Context) {
 	reqBody, err := ioutil.ReadAll(c.Request.Body)
 	if err != nil {
 		log.Println("[error] TeslaMateAPICarsCommandV1 error in first ioutil.ReadAll", err)
-		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsCommandV1", gin.H{"error": "internal"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsCommandV1", gin.H{"error": "internal ioutil reading error"})
 		return
 	}
 
@@ -100,7 +100,7 @@ func TeslaMateAPICarsCommandV1(c *gin.Context) {
 	// checking for errors in query when doing scan action
 	if err != nil {
 		log.Println("[error] TeslaMateAPICarsCommandV1 error in sql query:", err)
-		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsCommandV1", gin.H{"error": "internal"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsCommandV1", gin.H{"error": "internal sql query error"})
 		return
 	}
 
@@ -114,7 +114,7 @@ func TeslaMateAPICarsCommandV1(c *gin.Context) {
 	// check response error
 	if err != nil {
 		log.Println("[error] TeslaMateAPICarsCommandV1 error in http request to https://owner-api.teslamotors.com:", err)
-		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsCommandV1", gin.H{"error": "internal"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsCommandV1", gin.H{"error": "internal http request error"})
 		return
 	}
 
@@ -124,7 +124,7 @@ func TeslaMateAPICarsCommandV1(c *gin.Context) {
 	respBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.Println("[error] TeslaMateAPICarsCommandV1 error in second ioutil.ReadAll:", err)
-		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsCommandV1", gin.H{"error": "internal"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsCommandV1", gin.H{"error": "internal ioutil reading error"})
 		return
 	}
 	json.Unmarshal([]byte(respBody), &jsonData)

--- a/src/v1_TeslaMateAPICarsCommand.go
+++ b/src/v1_TeslaMateAPICarsCommand.go
@@ -22,34 +22,28 @@ func TeslaMateAPICarsCommandV1(c *gin.Context) {
 	// check if commands are enabled.. if not we need to abort
 	if !getEnvAsBool("ENABLE_COMMANDS", false) {
 		log.Println("[warning] TeslaMateAPICarsCommandV1 ENABLE_COMMANDS is not true.. returning 403 forbidden.")
-		c.JSON(http.StatusForbidden, gin.H{"error": "You are not allowed to access commands"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusForbidden, "TeslaMateAPICarsCommandV1", gin.H{"error": "You are not allowed to access commands"})
 		return
 	}
 
 	// if request method is GET return list of commands
 	if c.Request.Method == http.MethodGet {
-		c.JSON(http.StatusOK, gin.H{"enabled_commands": allowList})
+		TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPICarsCommandV1", gin.H{"enabled_commands": allowList})
 		return
 	}
 
 	// authentication for the endpoint
 	validToken, errorMessage := validateAuthToken(c)
 	if !validToken {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": errorMessage})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusUnauthorized, "TeslaMateAPICarsCommandV1", gin.H{"error": errorMessage})
 		return
 	}
 
-	// getting CarID param from URL
-	ParamCarID := c.Param("CarID")
-	var CarID int
-	if ParamCarID != "" {
-		CarID = convertStringToInteger(ParamCarID)
-	}
-
-	// validating that CarID is not zero
+	// getting CarID param from URL and validating that it's not zero
+	CarID := convertStringToInteger(c.Param("CarID"))
 	if CarID == 0 {
 		log.Println("[error] TeslaMateAPICarsCommandV1 CarID is invalid (zero)!")
-		c.JSON(http.StatusBadRequest, gin.H{"error": "CarID invalid"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusBadRequest, "TeslaMateAPICarsCommandV1", gin.H{"error": "CarID invalid"})
 		return
 	}
 
@@ -57,7 +51,7 @@ func TeslaMateAPICarsCommandV1(c *gin.Context) {
 	reqBody, err := ioutil.ReadAll(c.Request.Body)
 	if err != nil {
 		log.Println("[error] TeslaMateAPICarsCommandV1 error in first ioutil.ReadAll", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsCommandV1", gin.H{"error": "internal"})
 		return
 	}
 
@@ -71,7 +65,7 @@ func TeslaMateAPICarsCommandV1(c *gin.Context) {
 
 	if !checkArrayContainsString(allowList, command) {
 		log.Print("[warning] TeslaMateAPICarsCommandV1 command: " + command + " not allowed")
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusUnauthorized, "TeslaMateAPICarsCommandV1", gin.H{"error": "unauthorized"})
 		return
 	}
 
@@ -87,7 +81,8 @@ func TeslaMateAPICarsCommandV1(c *gin.Context) {
 
 	// checking for errors in query
 	if err != nil {
-		log.Fatal(err)
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsCommandV1", "Unable to load cars.", err.Error())
+		return
 	}
 
 	// defer closing rows
@@ -105,7 +100,7 @@ func TeslaMateAPICarsCommandV1(c *gin.Context) {
 	// checking for errors in query when doing scan action
 	if err != nil {
 		log.Println("[error] TeslaMateAPICarsCommandV1 error in sql query:", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsCommandV1", gin.H{"error": "internal"})
 		return
 	}
 
@@ -119,7 +114,7 @@ func TeslaMateAPICarsCommandV1(c *gin.Context) {
 	// check response error
 	if err != nil {
 		log.Println("[error] TeslaMateAPICarsCommandV1 error in http request to https://owner-api.teslamotors.com:", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsCommandV1", gin.H{"error": "internal"})
 		return
 	}
 
@@ -129,22 +124,13 @@ func TeslaMateAPICarsCommandV1(c *gin.Context) {
 	respBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.Println("[error] TeslaMateAPICarsCommandV1 error in second ioutil.ReadAll:", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsCommandV1", gin.H{"error": "internal"})
 		return
 	}
 	json.Unmarshal([]byte(respBody), &jsonData)
 
-	// print to log about request
-	if gin.IsDebugging() {
-		log.Println("[debug] TeslaMateAPICarsCommandV1 " + c.Request.RequestURI + " returned data:")
-		js, _ := json.Marshal(jsonData)
-		log.Printf("[debug] %s\n", js)
-	}
+	// return jsonData
+	// use TeslaMateAPIHandleOtherResponse since we use the statusCode from Tesla API
+	TeslaMateAPIHandleOtherResponse(c, resp.StatusCode, "TeslaMateAPICarsCommandV1", jsonData)
 
-	if resp.StatusCode == http.StatusOK {
-		log.Println("[info] TeslaMateAPICarsCommandV1 " + c.Request.RequestURI + " executed successful.")
-	} else {
-		log.Println("[error] TeslaMateAPICarsCommandV1 " + c.Request.RequestURI + " error in execution!")
-	}
-	c.JSON(resp.StatusCode, jsonData)
 }

--- a/src/v1_TeslaMateAPICarsDrives.go
+++ b/src/v1_TeslaMateAPICarsDrives.go
@@ -7,10 +7,11 @@ import (
 	_ "github.com/lib/pq"
 )
 
-const CarsDrivesError1 = "Unable to load drives."
-
 // TeslaMateAPICarsDrivesV1 func
 func TeslaMateAPICarsDrivesV1(c *gin.Context) {
+
+	// define error messages
+	var CarsDrivesError1 = "Unable to load drives."
 
 	// getting CarID param from URL
 	CarID := convertStringToInteger(c.Param("CarID"))

--- a/src/v1_TeslaMateAPICarsDrives.go
+++ b/src/v1_TeslaMateAPICarsDrives.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
 )
@@ -249,5 +247,5 @@ func TeslaMateAPICarsDrivesV1(c *gin.Context) {
 	}
 
 	// return jsonData
-	TeslaMateAPIHandleSuccessResponse(c, http.StatusOK, "TeslaMateAPICarsDrivesV1", jsonData)
+	TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPICarsDrivesV1", jsonData)
 }

--- a/src/v1_TeslaMateAPICarsDrives.go
+++ b/src/v1_TeslaMateAPICarsDrives.go
@@ -7,6 +7,8 @@ import (
 	_ "github.com/lib/pq"
 )
 
+const CarsDrivesError1 = "Unable to load drives."
+
 // TeslaMateAPICarsDrivesV1 func
 func TeslaMateAPICarsDrivesV1(c *gin.Context) {
 
@@ -140,7 +142,7 @@ func TeslaMateAPICarsDrivesV1(c *gin.Context) {
 
 	// checking for errors in query
 	if err != nil {
-		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesV1", "Unable to load drives.", err.Error())
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesV1", CarsDrivesError1, err.Error())
 		return
 	}
 
@@ -214,7 +216,7 @@ func TeslaMateAPICarsDrivesV1(c *gin.Context) {
 
 		// checking for errors after scanning
 		if err != nil {
-			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesV1", "Unable to load drives.", err.Error())
+			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesV1", CarsDrivesError1, err.Error())
 			return
 		}
 
@@ -225,7 +227,7 @@ func TeslaMateAPICarsDrivesV1(c *gin.Context) {
 	// checking for errors in the rows result
 	err = rows.Err()
 	if err != nil {
-		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesV1", "Unable to load drives.", err.Error())
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesV1", CarsDrivesError1, err.Error())
 		return
 	}
 

--- a/src/v1_TeslaMateAPICarsDrives.go
+++ b/src/v1_TeslaMateAPICarsDrives.go
@@ -138,14 +138,14 @@ func TeslaMateAPICarsDrivesV1(c *gin.Context) {
 		LIMIT $2 OFFSET $3;`
 	rows, err := db.Query(query, CarID, ResultShow, ResultPage)
 
-	// defer closing rows
-	defer rows.Close()
-
 	// checking for errors in query
 	if err != nil {
 		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesV1", "Unable to load drives.", err.Error())
 		return
 	}
+
+	// defer closing rows
+	defer rows.Close()
 
 	// looping through all results
 	for rows.Next() {

--- a/src/v1_TeslaMateAPICarsDrives.go
+++ b/src/v1_TeslaMateAPICarsDrives.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
 )
@@ -244,5 +246,5 @@ func TeslaMateAPICarsDrivesV1(c *gin.Context) {
 	}
 
 	// return jsonData
-	TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPICarsDrivesV1", jsonData)
+	TeslaMateAPIHandleSuccessResponse(c, http.StatusOK, "TeslaMateAPICarsDrivesV1", jsonData)
 }

--- a/src/v1_TeslaMateAPICarsDrivesDetails.go
+++ b/src/v1_TeslaMateAPICarsDrivesDetails.go
@@ -7,11 +7,12 @@ import (
 	_ "github.com/lib/pq"
 )
 
-const CarsDrivesDetailsError1 = "Unable to load drive."
-const CarsDrivesDetailsError2 = "Unable to load drive details."
-
 // TeslaMateAPICarsDrivesDetailsV1 func
 func TeslaMateAPICarsDrivesDetailsV1(c *gin.Context) {
+
+	// define error messages
+	var CarsDrivesDetailsError1 = "Unable to load drive."
+	var CarsDrivesDetailsError2 = "Unable to load drive details."
 
 	// getting CarID and DriveID param from URL
 	CarID := convertStringToInteger(c.Param("CarID"))

--- a/src/v1_TeslaMateAPICarsDrivesDetails.go
+++ b/src/v1_TeslaMateAPICarsDrivesDetails.go
@@ -163,14 +163,14 @@ func TeslaMateAPICarsDrivesDetailsV1(c *gin.Context) {
 		WHERE drives.car_id=$1 AND end_date IS NOT NULL AND drives.id = $2;`
 	rows, err := db.Query(query, CarID, DriveID)
 
-	// defer closing rows
-	defer rows.Close()
-
 	// checking for errors in query
 	if err != nil {
 		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesDetailsV1", "Unable to load drive.", err.Error())
 		return
 	}
+
+	// defer closing rows
+	defer rows.Close()
 
 	// looping through all results
 	for rows.Next() {
@@ -277,14 +277,14 @@ func TeslaMateAPICarsDrivesDetailsV1(c *gin.Context) {
 		 			ORDER BY id ASC;`
 		rows, err = db.Query(query, DriveID)
 
-		// defer closing rows
-		defer rows.Close()
-
 		// checking for errors in query
 		if err != nil {
 			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesDetailsV1", "Unable to load drive details.", err.Error())
 			return
 		}
+
+		// defer closing rows
+		defer rows.Close()
 
 		// looping through all results
 		for rows.Next() {

--- a/src/v1_TeslaMateAPICarsDrivesDetails.go
+++ b/src/v1_TeslaMateAPICarsDrivesDetails.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
 )
@@ -380,5 +382,5 @@ func TeslaMateAPICarsDrivesDetailsV1(c *gin.Context) {
 	}
 
 	// return jsonData
-	TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPICarsDrivesDetailsV1", jsonData)
+	TeslaMateAPIHandleSuccessResponse(c, http.StatusOK, "TeslaMateAPICarsDrivesDetailsV1", jsonData)
 }

--- a/src/v1_TeslaMateAPICarsDrivesDetails.go
+++ b/src/v1_TeslaMateAPICarsDrivesDetails.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
 )
@@ -386,5 +384,5 @@ func TeslaMateAPICarsDrivesDetailsV1(c *gin.Context) {
 	}
 
 	// return jsonData
-	TeslaMateAPIHandleSuccessResponse(c, http.StatusOK, "TeslaMateAPICarsDrivesDetailsV1", jsonData)
+	TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPICarsDrivesDetailsV1", jsonData)
 }

--- a/src/v1_TeslaMateAPICarsDrivesDetails.go
+++ b/src/v1_TeslaMateAPICarsDrivesDetails.go
@@ -7,6 +7,9 @@ import (
 	_ "github.com/lib/pq"
 )
 
+const CarsDrivesDetailsError1 = "Unable to load drive."
+const CarsDrivesDetailsError2 = "Unable to load drive details."
+
 // TeslaMateAPICarsDrivesDetailsV1 func
 func TeslaMateAPICarsDrivesDetailsV1(c *gin.Context) {
 
@@ -165,7 +168,7 @@ func TeslaMateAPICarsDrivesDetailsV1(c *gin.Context) {
 
 	// checking for errors in query
 	if err != nil {
-		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesDetailsV1", "Unable to load drive.", err.Error())
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesDetailsV1", CarsDrivesDetailsError1, err.Error())
 		return
 	}
 
@@ -238,7 +241,7 @@ func TeslaMateAPICarsDrivesDetailsV1(c *gin.Context) {
 
 		// checking for errors after scanning
 		if err != nil {
-			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesDetailsV1", "Unable to load drive.", err.Error())
+			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesDetailsV1", CarsDrivesDetailsError1, err.Error())
 			return
 		}
 
@@ -279,7 +282,7 @@ func TeslaMateAPICarsDrivesDetailsV1(c *gin.Context) {
 
 		// checking for errors in query
 		if err != nil {
-			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesDetailsV1", "Unable to load drive details.", err.Error())
+			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesDetailsV1", CarsDrivesDetailsError2, err.Error())
 			return
 		}
 
@@ -340,7 +343,7 @@ func TeslaMateAPICarsDrivesDetailsV1(c *gin.Context) {
 
 			// checking for errors after scanning
 			if err != nil {
-				TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesDetailsV1", "Unable to load drive details.", err.Error())
+				TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesDetailsV1", CarsDrivesDetailsError2, err.Error())
 				return
 			}
 
@@ -352,7 +355,7 @@ func TeslaMateAPICarsDrivesDetailsV1(c *gin.Context) {
 		// checking for errors in the rows result
 		err = rows.Err()
 		if err != nil {
-			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesDetailsV1", "Unable to load drive details.", err.Error())
+			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesDetailsV1", CarsDrivesDetailsError2, err.Error())
 			return
 		}
 
@@ -361,7 +364,7 @@ func TeslaMateAPICarsDrivesDetailsV1(c *gin.Context) {
 	// checking for errors in the rows result
 	err = rows.Err()
 	if err != nil {
-		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesDetailsV1", "Unable to load drive details.", err.Error())
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesDetailsV1", CarsDrivesDetailsError2, err.Error())
 		return
 	}
 

--- a/src/v1_TeslaMateAPICarsLogging.go
+++ b/src/v1_TeslaMateAPICarsLogging.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -21,34 +22,28 @@ func TeslaMateAPICarsLoggingV1(c *gin.Context) {
 	// check if commands are enabled.. if not we need to abort
 	if !getEnvAsBool("ENABLE_COMMANDS", false) {
 		log.Println("[warning] TeslaMateAPICarsLoggingV1 ENABLE_COMMANDS is not true.. returning 403 forbidden.")
-		c.JSON(http.StatusForbidden, gin.H{"error": "You are not allowed to access logging commands"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusForbidden, "TeslaMateAPICarsLoggingV1", gin.H{"error": "You are not allowed to access logging commands"})
 		return
 	}
 
 	// if request method is GET return list of commands
 	if c.Request.Method == http.MethodGet {
-		c.JSON(http.StatusOK, gin.H{"enabled_commands": allowList})
+		TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPICarsLoggingV1", gin.H{"enabled_commands": allowList})
 		return
 	}
 
 	// authentication for the endpoint
 	validToken, errorMessage := validateAuthToken(c)
 	if !validToken {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": errorMessage})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusUnauthorized, "TeslaMateAPICarsLoggingV1", gin.H{"error": errorMessage})
 		return
 	}
 
-	// getting CarID param from URL
-	ParamCarID := c.Param("CarID")
-	var CarID int
-	if ParamCarID != "" {
-		CarID = convertStringToInteger(ParamCarID)
-	}
-
-	// validating that CarID is not zero
+	// getting CarID param from URL and validating that it's not zero
+	CarID := convertStringToInteger(c.Param("CarID"))
 	if CarID == 0 {
 		log.Println("[error] TeslaMateAPICarsLoggingV1 CarID is invalid (zero)!")
-		c.JSON(http.StatusBadRequest, gin.H{"error": "CarID invalid"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusBadRequest, "TeslaMateAPICarsLoggingV1", gin.H{"error": "CarID invalid"})
 		return
 	}
 
@@ -56,7 +51,7 @@ func TeslaMateAPICarsLoggingV1(c *gin.Context) {
 	reqBody, err := ioutil.ReadAll(c.Request.Body)
 	if err != nil {
 		log.Println("[error] TeslaMateAPICarsLoggingV1 error in first ioutil.ReadAll", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsLoggingV1", gin.H{"error": "internal"})
 		return
 	}
 
@@ -66,7 +61,7 @@ func TeslaMateAPICarsLoggingV1(c *gin.Context) {
 
 	if !checkArrayContainsString(allowList, command) {
 		log.Print("[warning] TeslaMateAPICarsLoggingV1 command: " + command + " not allowed")
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusUnauthorized, "TeslaMateAPICarsLoggingV1", gin.H{"error": "unauthorized"})
 		return
 	}
 
@@ -77,7 +72,7 @@ func TeslaMateAPICarsLoggingV1(c *gin.Context) {
 	} else {
 		putURL = "http://"
 	}
-	putURL = putURL + getEnv("TESLAMATE_HOST", "teslamate") + ":" + getEnv("TESLAMATE_PORT", "4000") + "/api/car/" + ParamCarID + command
+	putURL = putURL + getEnv("TESLAMATE_HOST", "teslamate") + ":" + getEnv("TESLAMATE_PORT", "4000") + "/api/car/" + strconv.Itoa(CarID) + command
 	req, _ := http.NewRequest(http.MethodPut, putURL, strings.NewReader(string(reqBody)))
 	req.Header.Set("User-Agent", "TeslaMateApi/"+apiVersion+" https://github.com/tobiasehlert/teslamateapi")
 	resp, err := client.Do(req)
@@ -85,7 +80,7 @@ func TeslaMateAPICarsLoggingV1(c *gin.Context) {
 	// check response error
 	if err != nil {
 		log.Println("[error] TeslaMateAPICarsLoggingV1 error in http request to http://teslamate:", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsLoggingV1", gin.H{"error": "internal"})
 		return
 	}
 
@@ -95,22 +90,12 @@ func TeslaMateAPICarsLoggingV1(c *gin.Context) {
 	respBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.Println("[error] TeslaMateAPICarsLoggingV1 error in second ioutil.ReadAll:", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsLoggingV1", gin.H{"error": "internal"})
 		return
 	}
 	json.Unmarshal([]byte(respBody), &jsonData)
 
-	// print to log about request
-	if gin.IsDebugging() {
-		log.Println("[debug] TeslaMateAPICarsLoggingV1 " + c.Request.RequestURI + " returned data:")
-		js, _ := json.Marshal(jsonData)
-		log.Printf("[debug] %s\n", js)
-	}
-
-	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent {
-		log.Println("[info] TeslaMateAPICarsLoggingV1 " + c.Request.RequestURI + " executed successful.")
-	} else {
-		log.Println("[error] TeslaMateAPICarsLoggingV1 " + c.Request.RequestURI + " error in execution!")
-	}
-	c.JSON(resp.StatusCode, jsonData)
+	// return jsonData
+	// use TeslaMateAPIHandleOtherResponse since we use the statusCode from Tesla API
+	TeslaMateAPIHandleOtherResponse(c, resp.StatusCode, "TeslaMateAPICarsLoggingV1", jsonData)
 }

--- a/src/v1_TeslaMateAPICarsLogging.go
+++ b/src/v1_TeslaMateAPICarsLogging.go
@@ -51,7 +51,7 @@ func TeslaMateAPICarsLoggingV1(c *gin.Context) {
 	reqBody, err := ioutil.ReadAll(c.Request.Body)
 	if err != nil {
 		log.Println("[error] TeslaMateAPICarsLoggingV1 error in first ioutil.ReadAll", err)
-		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsLoggingV1", gin.H{"error": "internal"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsLoggingV1", gin.H{"error": "internal ioutil reading error"})
 		return
 	}
 
@@ -80,7 +80,7 @@ func TeslaMateAPICarsLoggingV1(c *gin.Context) {
 	// check response error
 	if err != nil {
 		log.Println("[error] TeslaMateAPICarsLoggingV1 error in http request to http://teslamate:", err)
-		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsLoggingV1", gin.H{"error": "internal"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsLoggingV1", gin.H{"error": "internal http request error"})
 		return
 	}
 
@@ -90,7 +90,7 @@ func TeslaMateAPICarsLoggingV1(c *gin.Context) {
 	respBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.Println("[error] TeslaMateAPICarsLoggingV1 error in second ioutil.ReadAll:", err)
-		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsLoggingV1", gin.H{"error": "internal"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsLoggingV1", gin.H{"error": "internal ioutil reading error"})
 		return
 	}
 	json.Unmarshal([]byte(respBody), &jsonData)

--- a/src/v1_TeslaMateAPICarsStatus.go
+++ b/src/v1_TeslaMateAPICarsStatus.go
@@ -281,9 +281,8 @@ func (s *statusCache) newMessage(c mqtt.Client, msg mqtt.Message) {
 // TeslaMateAPICarsStatusV1 func
 func (s *statusCache) TeslaMateAPICarsStatusV1(c *gin.Context) {
 	if s.mqttDisabled {
-		// TODO: use TeslaMateAPIHandleErrorResponse
 		log.Println("[notice] TeslaMateAPICarsStatusV1 DISABLE_MQTT is set to true.. can not return status for car without mqtt!")
-		c.JSON(http.StatusNotImplemented, gin.H{"error": "mqtt disabled.. status not accessible!"})
+		TeslaMateAPIHandleSuccessResponse(c, http.StatusNotImplemented, "TeslaMateAPICarsStatusV1", gin.H{"error": "mqtt disabled.. status not accessible!"})
 		return
 	}
 
@@ -296,8 +295,8 @@ func (s *statusCache) TeslaMateAPICarsStatusV1(c *gin.Context) {
 	s.mu.Unlock()
 
 	if stat == nil {
-		// TODO: use TeslaMateAPIHandleErrorResponse
-		c.JSON(http.StatusNoContent, gin.H{"error": "no info on this car ID"})
+		// or should it be http.StatusNoContent instead?
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsStatusV1", "no info on this car ID", "-")
 		return
 	}
 

--- a/src/v1_TeslaMateAPICarsStatus.go
+++ b/src/v1_TeslaMateAPICarsStatus.go
@@ -516,5 +516,5 @@ func (s *statusCache) TeslaMateAPICarsStatusV1(c *gin.Context) {
 	}
 
 	// return jsonData
-	TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPICarsStatusV1", jsonData)
+	TeslaMateAPIHandleSuccessResponse(c, http.StatusOK, "TeslaMateAPICarsStatusV1", jsonData)
 }

--- a/src/v1_TeslaMateAPICarsStatus.go
+++ b/src/v1_TeslaMateAPICarsStatus.go
@@ -282,7 +282,7 @@ func (s *statusCache) newMessage(c mqtt.Client, msg mqtt.Message) {
 func (s *statusCache) TeslaMateAPICarsStatusV1(c *gin.Context) {
 	if s.mqttDisabled {
 		log.Println("[notice] TeslaMateAPICarsStatusV1 DISABLE_MQTT is set to true.. can not return status for car without mqtt!")
-		TeslaMateAPIHandleSuccessResponse(c, http.StatusNotImplemented, "TeslaMateAPICarsStatusV1", gin.H{"error": "mqtt disabled.. status not accessible!"})
+		TeslaMateAPIHandleOtherResponse(c, http.StatusNotImplemented, "TeslaMateAPICarsStatusV1", gin.H{"error": "mqtt disabled.. status not accessible!"})
 		return
 	}
 
@@ -515,5 +515,5 @@ func (s *statusCache) TeslaMateAPICarsStatusV1(c *gin.Context) {
 	}
 
 	// return jsonData
-	TeslaMateAPIHandleSuccessResponse(c, http.StatusOK, "TeslaMateAPICarsStatusV1", jsonData)
+	TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPICarsStatusV1", jsonData)
 }

--- a/src/v1_TeslaMateAPICarsUpdates.go
+++ b/src/v1_TeslaMateAPICarsUpdates.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
 )
@@ -126,5 +124,5 @@ func TeslaMateAPICarsUpdatesV1(c *gin.Context) {
 	}
 
 	// return jsonData
-	TeslaMateAPIHandleSuccessResponse(c, http.StatusOK, "TeslaMateAPICarsUpdatesV1", jsonData)
+	TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPICarsUpdatesV1", jsonData)
 }

--- a/src/v1_TeslaMateAPICarsUpdates.go
+++ b/src/v1_TeslaMateAPICarsUpdates.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
 )
@@ -121,5 +123,5 @@ func TeslaMateAPICarsUpdatesV1(c *gin.Context) {
 	}
 
 	// return jsonData
-	TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPICarsUpdatesV1", jsonData)
+	TeslaMateAPIHandleSuccessResponse(c, http.StatusOK, "TeslaMateAPICarsUpdatesV1", jsonData)
 }

--- a/src/v1_TeslaMateAPICarsUpdates.go
+++ b/src/v1_TeslaMateAPICarsUpdates.go
@@ -7,10 +7,11 @@ import (
 	_ "github.com/lib/pq"
 )
 
-const CarsUpdatesError1 = "Unable to load updates."
-
 // TeslaMateAPICarsUpdatesV1 func
 func TeslaMateAPICarsUpdatesV1(c *gin.Context) {
+
+	// define error messages
+	var CarsUpdatesError1 = "Unable to load updates."
 
 	// getting CarID param from URL
 	CarID := convertStringToInteger(c.Param("CarID"))

--- a/src/v1_TeslaMateAPICarsUpdates.go
+++ b/src/v1_TeslaMateAPICarsUpdates.go
@@ -7,6 +7,8 @@ import (
 	_ "github.com/lib/pq"
 )
 
+const CarsUpdatesError1 = "Unable to load updates."
+
 // TeslaMateAPICarsUpdatesV1 func
 func TeslaMateAPICarsUpdatesV1(c *gin.Context) {
 
@@ -68,7 +70,7 @@ func TeslaMateAPICarsUpdatesV1(c *gin.Context) {
 
 	// checking for errors in query
 	if err != nil {
-		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsUpdatesV1", "Unable to load updates.", err.Error())
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsUpdatesV1", CarsUpdatesError1, err.Error())
 		return
 
 	}
@@ -93,7 +95,7 @@ func TeslaMateAPICarsUpdatesV1(c *gin.Context) {
 
 		// checking for errors after scanning
 		if err != nil {
-			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsUpdatesV1", "Unable to load updates.", err.Error())
+			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsUpdatesV1", CarsUpdatesError1, err.Error())
 			return
 		}
 
@@ -109,7 +111,7 @@ func TeslaMateAPICarsUpdatesV1(c *gin.Context) {
 	// checking for errors in the rows result
 	err = rows.Err()
 	if err != nil {
-		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsUpdatesV1", "Unable to load updates.", err.Error())
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsUpdatesV1", CarsUpdatesError1, err.Error())
 		return
 	}
 

--- a/src/v1_TeslaMateAPICarsUpdates.go
+++ b/src/v1_TeslaMateAPICarsUpdates.go
@@ -66,15 +66,15 @@ func TeslaMateAPICarsUpdatesV1(c *gin.Context) {
 		LIMIT $2 OFFSET $3;`
 	rows, err := db.Query(query, CarID, ResultShow, ResultPage)
 
-	// defer closing rows
-	defer rows.Close()
-
 	// checking for errors in query
 	if err != nil {
 		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsUpdatesV1", "Unable to load updates.", err.Error())
 		return
 
 	}
+
+	// defer closing rows
+	defer rows.Close()
 
 	// looping through all results
 	for rows.Next() {

--- a/src/v1_TeslaMateAPIGlobalsettings.go
+++ b/src/v1_TeslaMateAPIGlobalsettings.go
@@ -7,6 +7,8 @@ import (
 	_ "github.com/lib/pq"
 )
 
+const CarsGlobalsettingsError1 = "Unable to load settings."
+
 // TeslaMateAPIGlobalsettingsV1 func
 func TeslaMateAPIGlobalsettingsV1(c *gin.Context) {
 
@@ -69,7 +71,7 @@ func TeslaMateAPIGlobalsettingsV1(c *gin.Context) {
 
 	// checking for errors in query
 	if err != nil {
-		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPIGlobalsettingsV1", "Unable to load settings.", err.Error())
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPIGlobalsettingsV1", CarsGlobalsettingsError1, err.Error())
 		return
 	}
 
@@ -97,7 +99,7 @@ func TeslaMateAPIGlobalsettingsV1(c *gin.Context) {
 
 		// checking for errors after scanning
 		if err != nil {
-			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPIGlobalsettingsV1", "Unable to load settings.", err.Error())
+			TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPIGlobalsettingsV1", CarsGlobalsettingsError1, err.Error())
 			return
 		}
 
@@ -112,7 +114,7 @@ func TeslaMateAPIGlobalsettingsV1(c *gin.Context) {
 	// checking for errors in the rows result
 	err = rows.Err()
 	if err != nil {
-		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPIGlobalsettingsV1", "Unable to load settings.", err.Error())
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPIGlobalsettingsV1", CarsGlobalsettingsError1, err.Error())
 		return
 	}
 

--- a/src/v1_TeslaMateAPIGlobalsettings.go
+++ b/src/v1_TeslaMateAPIGlobalsettings.go
@@ -7,10 +7,11 @@ import (
 	_ "github.com/lib/pq"
 )
 
-const CarsGlobalsettingsError1 = "Unable to load settings."
-
 // TeslaMateAPIGlobalsettingsV1 func
 func TeslaMateAPIGlobalsettingsV1(c *gin.Context) {
+
+	// define error messages
+	var CarsGlobalsettingsError1 = "Unable to load settings."
 
 	// creating structs for /globalsettings
 	// AccountInfo struct - child of GlobalSettings

--- a/src/v1_TeslaMateAPIGlobalsettings.go
+++ b/src/v1_TeslaMateAPIGlobalsettings.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
 )
@@ -128,5 +126,5 @@ func TeslaMateAPIGlobalsettingsV1(c *gin.Context) {
 	}
 
 	// return jsonData
-	TeslaMateAPIHandleSuccessResponse(c, http.StatusOK, "TeslaMateAPIGlobalsettingsV1", jsonData)
+	TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPIGlobalsettingsV1", jsonData)
 }

--- a/src/v1_TeslaMateAPIGlobalsettings.go
+++ b/src/v1_TeslaMateAPIGlobalsettings.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
 )
@@ -123,5 +125,5 @@ func TeslaMateAPIGlobalsettingsV1(c *gin.Context) {
 	}
 
 	// return jsonData
-	TeslaMateAPIHandleSuccessResponse(c, "TeslaMateAPIGlobalsettingsV1", jsonData)
+	TeslaMateAPIHandleSuccessResponse(c, http.StatusOK, "TeslaMateAPIGlobalsettingsV1", jsonData)
 }

--- a/src/v1_TeslaMateAPIGlobalsettings.go
+++ b/src/v1_TeslaMateAPIGlobalsettings.go
@@ -67,14 +67,14 @@ func TeslaMateAPIGlobalsettingsV1(c *gin.Context) {
 		LIMIT 1;`
 	rows, err := db.Query(query)
 
-	// defer closing rows
-	defer rows.Close()
-
 	// checking for errors in query
 	if err != nil {
 		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPIGlobalsettingsV1", "Unable to load settings.", err.Error())
 		return
 	}
+
+	// defer closing rows
+	defer rows.Close()
 
 	// looping through all results
 	for rows.Next() {

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -184,7 +184,7 @@ func TeslaMateAPIHandleErrorResponse(c *gin.Context, s1 string, s2 string, s3 st
 	c.JSON(http.StatusOK, gin.H{"error": s2})
 }
 
-func TeslaMateAPIHandleSuccessResponse(c *gin.Context, httpCode int, s string, j JSONData) {
+func TeslaMateAPIHandleSuccessResponse(c *gin.Context, httpCode int, s string, j interface{}) {
 
 	// print to log about request
 	if gin.IsDebugging() {

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -187,7 +187,7 @@ func TeslaMateAPIHandleSuccessResponse(c *gin.Context, s string, j JSONData) {
 	// print to log about request
 	if gin.IsDebugging() {
 		log.Println("[debug] " + s + " - (" + c.Request.RequestURI + ") returned data:")
-		js, _ := json.Marshal(jsonData)
+		js, _ := json.Marshal(j)
 		log.Printf("[debug] %s\n", js)
 	}
 	// return successful response

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -178,13 +178,13 @@ func initDBconnection() {
 	}
 }
 
-func TeslaMateAPIHandleErrorResponse(c *gin.Context, s string) {
-    log.Println("[error] TeslaMateAPICarsChargesDetailsV1 " + c.Request.RequestURI + " error in execution! " + s)
-    c.JSON(http.StatusOK, gin.H{"error": s})
+func TeslaMateAPIHandleErrorResponse(c *gin.Context, s1 string, s2 string) {
+    log.Println("[error] " + s1 + " - " + c.Request.RequestURI + " error in execution! " + s2)
+    c.JSON(http.StatusOK, gin.H{"error": s2})
 }
 
-func TeslaMateAPIHandleSuccessResponse(c *gin.Context, j JSONData) {
-    log.Println("[info] TeslaMateAPICarsChargesDetailsV1 " + c.Request.RequestURI + " executed successful.")
+func TeslaMateAPIHandleSuccessResponse(c *gin.Context, s string, j JSONData) {
+    log.Println("[info] " + s + " - " + c.Request.RequestURI + " executed successful.")
     c.JSON(http.StatusOK, j)
 }
 

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -178,14 +178,14 @@ func initDBconnection() {
 	}
 }
 
-func TeslaMateAPIHandleErrorResponse(c *gin.Context, s1 string, s2 string) {
-    log.Println("[error] " + s1 + " - (" + c.Request.RequestURI + ") error in execution! " + s2)
-    c.JSON(http.StatusOK, gin.H{"error": s2})
+func TeslaMateAPIHandleErrorResponse(c *gin.Context, s1 string, s2 string, s3 string) {
+	log.Println("[error] " + s1 + " - (" + c.Request.RequestURI + "). " + s2 + "; " + s3)
+	c.JSON(http.StatusOK, gin.H{"error": s2})
 }
 
 func TeslaMateAPIHandleSuccessResponse(c *gin.Context, s string, j JSONData) {
-    log.Println("[info] " + s + " - (" + c.Request.RequestURI + ") executed successfully.")
-    c.JSON(http.StatusOK, j)
+	log.Println("[info] " + s + " - (" + c.Request.RequestURI + ") executed successfully.")
+	c.JSON(http.StatusOK, j)
 }
 
 func getTimeInTimeZone(datestring string) string {

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -184,7 +184,8 @@ func TeslaMateAPIHandleErrorResponse(c *gin.Context, s1 string, s2 string, s3 st
 	c.JSON(http.StatusOK, gin.H{"error": s2})
 }
 
-func TeslaMateAPIHandleSuccessResponse(c *gin.Context, s string, j JSONData) {
+func TeslaMateAPIHandleSuccessResponse(c *gin.Context, httpCode int, s string, j JSONData) {
+
 	// print to log about request
 	if gin.IsDebugging() {
 		log.Println("[debug] " + s + " - (" + c.Request.RequestURI + ") returned data:")
@@ -193,7 +194,7 @@ func TeslaMateAPIHandleSuccessResponse(c *gin.Context, s string, j JSONData) {
 	}
 	// return successful response
 	log.Println("[info] " + s + " - (" + c.Request.RequestURI + ") executed successfully.")
-	c.JSON(http.StatusOK, j)
+	c.JSON(httpCode, j)
 }
 
 func getTimeInTimeZone(datestring string) string {

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -179,12 +179,12 @@ func initDBconnection() {
 }
 
 func TeslaMateAPIHandleErrorResponse(c *gin.Context, s1 string, s2 string) {
-    log.Println("[error] " + s1 + " - " + c.Request.RequestURI + " error in execution! " + s2)
+    log.Println("[error] " + s1 + " - (" + c.Request.RequestURI + ") error in execution! " + s2)
     c.JSON(http.StatusOK, gin.H{"error": s2})
 }
 
 func TeslaMateAPIHandleSuccessResponse(c *gin.Context, s string, j JSONData) {
-    log.Println("[info] " + s + " - " + c.Request.RequestURI + " executed successful.")
+    log.Println("[info] " + s + " - (" + c.Request.RequestURI + ") executed successfully.")
     c.JSON(http.StatusOK, j)
 }
 

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -184,17 +184,23 @@ func TeslaMateAPIHandleErrorResponse(c *gin.Context, s1 string, s2 string, s3 st
 	c.JSON(http.StatusOK, gin.H{"error": s2})
 }
 
-func TeslaMateAPIHandleSuccessResponse(c *gin.Context, httpCode int, s string, j interface{}) {
+func TeslaMateAPIHandleOtherResponse(c *gin.Context, httpCode int, s string, j interface{}) {
+	// return successful response
+	log.Println("[info] " + s + " - (" + c.Request.RequestURI + ") executed successfully.")
+	c.JSON(httpCode, j)
+}
 
+func TeslaMateAPIHandleSuccessResponse(c *gin.Context, s string, j interface{}) {
 	// print to log about request
 	if gin.IsDebugging() {
 		log.Println("[debug] " + s + " - (" + c.Request.RequestURI + ") returned data:")
 		js, _ := json.Marshal(j)
 		log.Printf("[debug] %s\n", js)
 	}
+
 	// return successful response
 	log.Println("[info] " + s + " - (" + c.Request.RequestURI + ") executed successfully.")
-	c.JSON(httpCode, j)
+	c.JSON(http.StatusOK, j)
 }
 
 func getTimeInTimeZone(datestring string) string {

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -184,6 +184,13 @@ func TeslaMateAPIHandleErrorResponse(c *gin.Context, s1 string, s2 string, s3 st
 }
 
 func TeslaMateAPIHandleSuccessResponse(c *gin.Context, s string, j JSONData) {
+	// print to log about request
+	if gin.IsDebugging() {
+		log.Println("[debug] " + s + " - (" + c.Request.RequestURI + ") returned data:")
+		js, _ := json.Marshal(jsonData)
+		log.Printf("[debug] %s\n", js)
+	}
+	// return successful response
 	log.Println("[info] " + s + " - (" + c.Request.RequestURI + ") executed successfully.")
 	c.JSON(http.StatusOK, j)
 }

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -178,6 +178,16 @@ func initDBconnection() {
 	}
 }
 
+func TeslaMateAPIHandleErrorResponse(c *gin.Context, s string) {
+    log.Println("[error] TeslaMateAPICarsChargesDetailsV1 " + c.Request.RequestURI + " error in execution! " + s)
+    c.JSON(http.StatusOK, gin.H{"error": s})
+}
+
+func TeslaMateAPIHandleSuccessResponse(c *gin.Context, j JSONData) {
+    log.Println("[info] TeslaMateAPICarsChargesDetailsV1 " + c.Request.RequestURI + " executed successful.")
+    c.JSON(http.StatusOK, j)
+}
+
 func getTimeInTimeZone(datestring string) string {
 
 	// getting timezone from environment


### PR DESCRIPTION
Better response handler for TeslaMateApi.

Two functions that are supposed to be used from all enpoints for a "same" way of handling responses:
- TeslaMateAPIHandleErrorResponse
- TeslaMateAPIHandleOtherResponse
- TeslaMateAPIHandleSuccessResponse

Linked issue:
- resolves #77

Related PRs:
- #76
- #79
