### PR TITLE
Add support for `set_charging_amps` command

### DIFF
--- a/src/CommandSupport.go
+++ b/src/CommandSupport.go
@@ -97,7 +97,8 @@ func initCommandAllowList() {
 			"/command/charge_stop",
 			"/command/charge_standard",
 			"/command/charge_max_range",
-			"/command/set_charge_limit")
+			"/command/set_charge_limit",
+			"/command/set_charging_amps")
 	}
 
 	// https://tesla-api.timdorr.com/vehicle/commands/climate


### PR DESCRIPTION
Per discussion on the [timdorr/tesla-api](https://github.com/timdorr/tesla-api/discussions/455) repo.

This accepts a `charging_amps` parameter.

As far as I can tell, this is the only place a change is required, but let me know if something further is needed.

