### PR TITLE
Add support for new endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Basically the same environment variables for the database, mqqt and timezone nee
 | **COMMANDS_MEDIA** | boolean | *false* |
 | **COMMANDS_SHARING** | boolean | *false* |
 | **COMMANDS_SOFTWAREUPDATE** | boolean | *false* |
+| **COMMANDS_UNKNOWN** | boolean | *false* |
 
 ## API documentation
 

--- a/src/CommandSupport.go
+++ b/src/CommandSupport.go
@@ -95,8 +95,6 @@ func initCommandAllowList() {
 			"/command/charge_port_door_close",
 			"/command/charge_start",
 			"/command/charge_stop",
-			"/command/charge_standard",
-			"/command/charge_max_range",
 			"/command/set_charge_limit",
 			"/command/set_charging_amps")
 	}

--- a/src/CommandSupport.go
+++ b/src/CommandSupport.go
@@ -97,7 +97,8 @@ func initCommandAllowList() {
 			"/command/charge_stop",
 			"/command/charge_standard",
 			"/command/charge_max_range",
-			"/command/set_charge_limit")
+			"/command/set_charge_limit",
+			"/command/set_charging_amps")
 	}
 
 	// https://tesla-api.timdorr.com/vehicle/commands/climate

--- a/src/CommandSupport.go
+++ b/src/CommandSupport.go
@@ -139,6 +139,13 @@ func initCommandAllowList() {
 			"/command/cancel_software_update")
 	}
 
+	// not documentet and unsorted new endpoints
+	if getEnvAsBool("COMMANDS_UNKNOWN", false) || allowAll {
+		allowList = append(allowList,
+			"/command/upcoming_calendar_entries",
+			"/command/dashcam_save_clip")
+	}
+
 	// if allowList is empty, read COMMANDS_ALLOWLIST and append to allowList
 	commandAllowListLocation := getEnv("COMMANDS_ALLOWLIST", "allow_list.json")
 	if len(allowList) == 0 {

--- a/src/CommandSupport.go
+++ b/src/CommandSupport.go
@@ -96,7 +96,8 @@ func initCommandAllowList() {
 			"/command/charge_start",
 			"/command/charge_stop",
 			"/command/set_charge_limit",
-			"/command/set_charging_amps")
+			"/command/set_charging_amps",
+			"/command/set_scheduled_charging")
 	}
 
 	// https://tesla-api.timdorr.com/vehicle/commands/climate
@@ -107,7 +108,9 @@ func initCommandAllowList() {
 			"/command/set_temps",
 			"/command/set_preconditioning_max",
 			"/command/remote_seat_heater_request",
-			"/command/remote_steering_wheel_heater_request")
+			"/command/remote_steering_wheel_heater_request",
+			"/command/set_bioweapon_mode",
+			"/command/set_scheduled_departure")
 	}
 
 	// https://tesla-api.timdorr.com/vehicle/commands/media
@@ -124,7 +127,9 @@ func initCommandAllowList() {
 
 	// https://tesla-api.timdorr.com/vehicle/commands/sharing
 	if getEnvAsBool("COMMANDS_SHARING", false) || allowAll {
-		allowList = append(allowList, "/command/share")
+		allowList = append(allowList,
+			"/command/share",
+			"/command/navigation_sc_request")
 	}
 
 	// https://tesla-api.timdorr.com/vehicle/commands/softwareupdate

--- a/src/CommandSupport.go
+++ b/src/CommandSupport.go
@@ -97,7 +97,8 @@ func initCommandAllowList() {
 			"/command/charge_stop",
 			"/command/set_charge_limit",
 			"/command/set_charging_amps",
-			"/command/set_scheduled_charging")
+			"/command/set_scheduled_charging",
+			"/command/set_scheduled_departure")
 	}
 
 	// https://tesla-api.timdorr.com/vehicle/commands/climate
@@ -109,8 +110,7 @@ func initCommandAllowList() {
 			"/command/set_preconditioning_max",
 			"/command/remote_seat_heater_request",
 			"/command/remote_steering_wheel_heater_request",
-			"/command/set_bioweapon_mode",
-			"/command/set_scheduled_departure")
+			"/command/set_bioweapon_mode")
 	}
 
 	// https://tesla-api.timdorr.com/vehicle/commands/media


### PR DESCRIPTION
Added commands:
- /command/set_charging_amps (#112)
- /command/set_scheduled_charging
- /command/set_bioweapon_mode
- /command/set_scheduled_departure
- /command/navigation_sc_request
- /command/upcoming_calendar_entries
- /command/dashcam_save_clip

Removed commands:
- /command/charge_standard
- /command/charge_max_range

Added commands section:
- COMMANDS_UNKNOWN

Updating commands based on [timdorr/tesla-api endpoints.md](https://github.com/timdorr/tesla-api/blob/9d4345631109603ff2770412e8786ac98d033bd5/docs/miscellaneous/endpoints.md) file for version _4.2.2_.