### PR TITLE
Fix append of commands to allowList

### DIFF
--- a/src/CommandSupport.go
+++ b/src/CommandSupport.go
@@ -143,7 +143,7 @@ func initCommandAllowList() {
 		// checking if env is set from key or if all should be allowed
 		if getEnvAsBool(key, false) || allowAll {
 			// appending to allowList
-			allowList = append(allowList, strings.Join(CommandList[key], " "))
+			allowList = append(allowList, CommandList[key]...)
 		}
 	}
 


### PR DESCRIPTION
Expected JSON:
```json
{"enabled_commands":["/logging/resume","/logging/suspend","/command/honk_horn","/command/flash_lights"]}
```

Actual JSON:
```json
{"enabled_commands":["/logging/resume /logging/suspend","/command/honk_horn /command/flash_lights"]}
```


Issue appeared after #132.