### PR TITLE
adding 404 for not found endpoints

### DIFF
--- a/src/webserver.go
+++ b/src/webserver.go
@@ -71,6 +71,11 @@ func main() {
 	// gin middleware to enable GZIP support
 	r.Use(gzip.Gzip(gzip.DefaultCompression))
 
+	// set 404 not found page
+	r.NoRoute(func(c *gin.Context) {
+		c.JSON(http.StatusNotFound, gin.H{"code": "PAGE_NOT_FOUND", "message": "Page not found"})
+	})
+
 	// root endpoint telling API is running
 	r.GET("/", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"message": "TeslaMateApi container runnnig..", "path": r.BasePath()})


### PR DESCRIPTION
Returning proper 404 and also a JSON-formatted error response.