### PR TITLE
Support execute commands for China region cars 

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -75,7 +75,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/thanhpk/randstr v1.0.4 h1:IN78qu/bR+My+gHCvMEXhR/i5oriVHcTB/BJJIRTsNo=
 github.com/thanhpk/randstr v1.0.4/go.mod h1:M/H2P1eNLZzlDwAzpkkkUvoyNNMbzRGhESZuEQk3r0U=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
-github.com/ugorji/go v1.2.7 h1:qYhyWUUd6WbiM+C6JZAUkIJt/1WrjzNHY9+KCIjVqTo=
 github.com/ugorji/go v1.2.7/go.mod h1:nF9osbDWLy6bDVv/Rtoh6QgnvNDpmCalQV5urGCCS6M=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=

--- a/src/EncryptionSupport.go
+++ b/src/EncryptionSupport.go
@@ -4,9 +4,20 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
 	"log"
+	"net/url"
+	"strings"
 
 	"github.com/gin-gonic/gin"
+)
+
+type Region string
+
+const (
+	China  Region = "China"
+	Global        = "Global"
 )
 
 // decryptAccessToken funct to decrypt tokens from database
@@ -91,4 +102,29 @@ func decryptAccessToken(data string, encryptionKey string) string {
 	}
 
 	return string(plaintext)
+}
+
+// Get tesla web API endpoint url from iss in accessToken
+// AccessToken is a JWT
+func GetCarRegion(accessToken string) Region {
+	payload := strings.Split(accessToken, ".")
+	if len(payload) != 3 {
+		return Global
+	}
+	decodedStr, err := base64.RawStdEncoding.DecodeString(payload[1])
+	if err != nil {
+		return Global
+	}
+	var result map[string]interface{}
+	if err = json.Unmarshal(decodedStr, &result); err != nil {
+		return Global
+	}
+	issUrl, err := url.Parse(result["iss"].(string))
+	if err != nil {
+		return Global
+	}
+	if strings.HasSuffix(issUrl.Host, ".cn") {
+		return China
+	}
+	return Global
 }

--- a/src/EncryptionSupport.go
+++ b/src/EncryptionSupport.go
@@ -104,9 +104,8 @@ func decryptAccessToken(data string, encryptionKey string) string {
 	return string(plaintext)
 }
 
-// Get tesla web API endpoint url from iss in accessToken
-// AccessToken is a JWT
-func GetCarRegion(accessToken string) Region {
+// getCarRegion function to get URL from iis in accessToken
+func getCarRegion(accessToken string) Region {
 	payload := strings.Split(accessToken, ".")
 	if len(payload) != 3 {
 		return Global

--- a/src/EncryptionSupport.go
+++ b/src/EncryptionSupport.go
@@ -13,11 +13,11 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-type Region string
+type CarRegionAPI string
 
 const (
-	China  Region = "China"
-	Global        = "Global"
+	ChinaAPI  CarRegionAPI = "China"
+	GlobalAPI              = "Global"
 )
 
 // decryptAccessToken funct to decrypt tokens from database
@@ -104,26 +104,26 @@ func decryptAccessToken(data string, encryptionKey string) string {
 	return string(plaintext)
 }
 
-// getCarRegion function to get URL from iis in accessToken
-func getCarRegion(accessToken string) Region {
+// getCarRegionAPI function to get URL from iis in accessToken
+func getCarRegionAPI(accessToken string) CarRegionAPI {
 	payload := strings.Split(accessToken, ".")
 	if len(payload) != 3 {
-		return Global
+		return GlobalAPI
 	}
 	decodedStr, err := base64.RawStdEncoding.DecodeString(payload[1])
 	if err != nil {
-		return Global
+		return GlobalAPI
 	}
 	var result map[string]interface{}
 	if err = json.Unmarshal(decodedStr, &result); err != nil {
-		return Global
+		return GlobalAPI
 	}
 	issUrl, err := url.Parse(result["iss"].(string))
 	if err != nil {
-		return Global
+		return GlobalAPI
 	}
 	if strings.HasSuffix(issUrl.Host, ".cn") {
-		return China
+		return ChinaAPI
 	}
-	return Global
+	return GlobalAPI
 }

--- a/src/v1_TeslaMateAPICarsCommand.go
+++ b/src/v1_TeslaMateAPICarsCommand.go
@@ -110,8 +110,8 @@ func TeslaMateAPICarsCommandV1(c *gin.Context) {
 	// decrypt access token
 	TeslaAccessToken = decryptAccessToken(TeslaAccessToken, teslaMateEncryptionKey)
 
-	switch getCarRegion(TeslaAccessToken) {
-	case China:
+	switch getCarRegionAPI(TeslaAccessToken) {
+	case ChinaAPI:
 		TeslaEndpointUrl = "https://owner-api.vn.cloud.tesla.cn"
 	default:
 		TeslaEndpointUrl = "https://owner-api.teslamotors.com"

--- a/src/v1_TeslaMateAPICarsCommand.go
+++ b/src/v1_TeslaMateAPICarsCommand.go
@@ -17,11 +17,10 @@ func TeslaMateAPICarsCommandV1(c *gin.Context) {
 
 	// creating required vars
 	var (
-		CarsCommandsError1               = "Unable to load cars."
-		TeslaAccessToken, TeslaVehicleID string
-		EndpointUrl                      string
-		jsonData                         map[string]interface{}
-		err                              error
+		CarsCommandsError1                                 = "Unable to load cars."
+		TeslaAccessToken, TeslaVehicleID, TeslaEndpointUrl string
+		jsonData                                           map[string]interface{}
+		err                                                error
 	)
 
 	// check if commands are enabled.. if not we need to abort
@@ -111,16 +110,15 @@ func TeslaMateAPICarsCommandV1(c *gin.Context) {
 	// decrypt access token
 	TeslaAccessToken = decryptAccessToken(TeslaAccessToken, teslaMateEncryptionKey)
 
-	region := GetCarRegion(TeslaAccessToken)
-	switch region {
+	switch getCarRegion(TeslaAccessToken) {
 	case China:
-		EndpointUrl = "https://owner-api.vn.cloud.tesla.cn"
+		TeslaEndpointUrl = "https://owner-api.vn.cloud.tesla.cn"
 	default:
-		EndpointUrl = "https://owner-api.teslamotors.com"
+		TeslaEndpointUrl = "https://owner-api.teslamotors.com"
 	}
 
 	client := &http.Client{}
-	req, _ := http.NewRequest(http.MethodPost, EndpointUrl+"/api/1/vehicles/"+TeslaVehicleID+command, strings.NewReader(string(reqBody)))
+	req, _ := http.NewRequest(http.MethodPost, TeslaEndpointUrl+"/api/1/vehicles/"+TeslaVehicleID+command, strings.NewReader(string(reqBody)))
 	req.Header.Set("Authorization", "Bearer "+TeslaAccessToken)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "TeslaMateApi/"+apiVersion+" (+https://github.com/tobiasehlert/teslamateapi)")
@@ -128,7 +126,7 @@ func TeslaMateAPICarsCommandV1(c *gin.Context) {
 
 	// check response error
 	if err != nil {
-		log.Println("[error] TeslaMateAPICarsCommandV1 error in http request to "+EndpointUrl, err)
+		log.Println("[error] TeslaMateAPICarsCommandV1 error in http request to "+TeslaEndpointUrl, err)
 		TeslaMateAPIHandleOtherResponse(c, http.StatusInternalServerError, "TeslaMateAPICarsCommandV1", gin.H{"error": "internal http request error"})
 		return
 	}


### PR DESCRIPTION
This is mostly based on TeslaMate: https://github.com/adriankumpf/teslamate/blob/f91f8d58140a4e151ee492a03b483799c63ed7aa/lib/tesla_api/vehicle.ex#L27 

Tesla China uses different API endpoint, this PR resolve "iss" field from access_token.
Global region are not affected.