### PR TITLE
Feature: adding support for k8s health endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,9 @@ More detailed documentation of every endpoint will come..
 - GET `/api/v1/cars/:CarID/updates`
 - POST `/api/v1/cars/:CarID/wake_up`
 - GET `/api/v1/globalsettings`
+- GET `/api/healthz`
 - GET `/api/ping`
+- GET `/api/readyz`
 
 ### Authentication
 

--- a/src/v1_TeslaMateAPICarsStatus.go
+++ b/src/v1_TeslaMateAPICarsStatus.go
@@ -190,6 +190,9 @@ func startMQTT() (*statusCache, error) {
 
 	s.topicScan = fmt.Sprintf("teslamate%s/cars/%%d/%%s", getMQTTNameSpace())
 
+	// setting readyz endpoint to true (when using MQTT)
+	isReady.Store(true)
+
 	// Thats all - newMessage will be called when something new arrives
 	return &s, nil
 }

--- a/src/v1_TeslaMateAPICarsStatus.go
+++ b/src/v1_TeslaMateAPICarsStatus.go
@@ -218,12 +218,17 @@ func (s *statusCache) connectedHandler(c mqtt.Client) {
 	}
 	log.Println("[info] subscribed to: " + topic)
 
+	// setting readyz endpoint to true (when using MQTT)
+	isReady.Store(true)
 }
 
 // connectionLost - called by mqtt package when the connection get lost
 func (s *statusCache) connectionLost(c mqtt.Client, err error) {
 	log.Println("[error] MQTT connection lost: " + err.Error())
 	s.mqttConnected = false
+
+	// setting readyz endpoint to false (when using MQTT)
+	isReady.Store(false)
 }
 
 // newMessage - called by mqtt package when new message received


### PR DESCRIPTION
Adds two new endpoints to application so that kubernetes can monitor it.

- GET `/api/healthz`
- GET `/api/readyz`

fix #190