### PR TITLE
alignment of commands to version 4.23.6

### DIFF
--- a/src/CommandSupport.go
+++ b/src/CommandSupport.go
@@ -109,6 +109,10 @@ func initCommandAllowList() {
 		"/command/set_bioweapon_mode",
 		"/command/set_climate_keeper_mode",
 		"/command/remote_auto_seat_climate_request",
+		"/command/set_cop_temp",
+		"/command/set_cabin_overheat_protection",
+		"/command/remote_auto_steering_wheel_heat_climate_request", // missing documentation
+		"/command/remote_steering_wheel_heat_level_request",        // missing documentation
 	}
 
 	// https://tesla-api.timdorr.com/vehicle/commands/media
@@ -120,12 +124,12 @@ func initCommandAllowList() {
 		"/command/media_prev_fav",
 		"/command/media_volume_up",
 		"/command/media_volume_down",
+		"/command/adjust_volume",
 	}
 
 	// https://tesla-api.timdorr.com/vehicle/commands/sharing
 	CommandList["COMMANDS_SHARING"] = []string{
 		"/command/share",
-		"/command/navigation_sc_request",
 	}
 
 	// https://tesla-api.timdorr.com/vehicle/commands/softwareupdate
@@ -138,6 +142,16 @@ func initCommandAllowList() {
 	CommandList["COMMANDS_UNKNOWN"] = []string{
 		"/command/upcoming_calendar_entries",
 		"/command/dashcam_save_clip",
+		"/command/navigation_sc_request",
+		"/command/remote_boombox",
+		"/command/get_active_route",
+		"/command/get_managed_charging_sites",
+		"/command/add_managed_charging_site",
+		"/command/remove_managed_charging_site",
+		"/command/update_charge_on_solar_feature",
+		"/command/get_charge_on_solar_feature",
+		"/command/take_drivenote",
+		"/command/navigation_gps_request",
 	}
 
 	// allow all commands available below


### PR DESCRIPTION
Added commands:
- /command/set_cop_temp
- /command/set_cabin_overheat_protection
- /command/remote_auto_steering_wheel_heat_climate_request (_\*missing documentation_)
- /command/remote_steering_wheel_heat_level_request (_\*missing documentation_)
- /command/adjust_volume
- /command/remote_boombox
- /command/get_active_route
- /command/get_managed_charging_sites
- /command/add_managed_charging_site
- /command/remove_managed_charging_site
- /command/update_charge_on_solar_feature
- /command/get_charge_on_solar_feature
- /command/take_drivenote
- /command/navigation_gps_request

Moved command:
- /command/navigation_sc_request

Note:
\* Even though marked commands are missing documentation on https://github.com/timdorr/tesla-api, they are placed under climate section based on naming.

Updating commands based on [timdorr/tesla-api ownerapi_endpoints.json](https://github.com/timdorr/tesla-api/blob/b0c8e90c7c7d10604866ec7262d2e7d96d5070b4/ownerapi_endpoints.json) file for version 4.23.6.