### PR TITLE
Fix permission issues with Dockerfile nonroot implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN addgroup -S nonroot && \
 USER nonroot:nonroot
 
 # copy binary from builder
-COPY --from=builder --chown=nonroot:nonroot --chmod=644 /go/src/app .
+COPY --from=builder --chown=nonroot:nonroot --chmod=544 /go/src/app .
 
 # expose port 8080
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,21 +23,22 @@ RUN CGO_ENABLED=0 go build -ldflags="-w -s -X 'main.apiVersion=${apiVersion}'" -
 # get alpine container
 FROM alpine:3.19.1 as app
 
-# create nonroot user and group
-RUN addgroup -S nonroot \
-  && adduser -S nonroot -G nonroot
+# create workdir
+WORKDIR /opt/app
 
 # add ca-certificates and tzdata
 RUN apk --no-cache add ca-certificates tzdata
 
-# create workdir
-WORKDIR /root/
+# create nonroot user and group
+RUN addgroup -S nonroot && \
+  adduser -S nonroot -G nonroot && \
+  chown -R nonroot:nonroot .
+
+# set user to nonroot
+USER nonroot:nonroot
 
 # copy binary from builder
-COPY --from=builder /go/src/app .
-
-# set user
-USER nonroot
+COPY --from=builder --chown=nonroot:nonroot /go/src/app .
 
 # expose port 8080
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN addgroup -S nonroot && \
 USER nonroot:nonroot
 
 # copy binary from builder
-COPY --from=builder --chown=nonroot:nonroot /go/src/app .
+COPY --from=builder --chown=nonroot:nonroot --chmod=644 /go/src/app .
 
 # expose port 8080
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # get golang container
-FROM golang:1.22.1 as builder
+FROM golang:1.22.1 AS builder
 
 # get args
 ARG apiVersion=unknown
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 go build -ldflags="-w -s -X 'main.apiVersion=${apiVersion}'" -
 
 
 # get alpine container
-FROM alpine:3.19.1 as app
+FROM alpine:3.19.1 AS app
 
 # create workdir
 WORKDIR /opt/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # get golang container
-FROM golang:1.22.1
+FROM golang:1.22.1 as builder
 
 # get args
 ARG apiVersion=unknown
@@ -21,20 +21,20 @@ RUN CGO_ENABLED=0 go build -ldflags="-w -s -X 'main.apiVersion=${apiVersion}'" -
 
 
 # get alpine container
-FROM alpine:3.19.1
+FROM alpine:3.19.1 as app
 
-# create nonroot user
+# create nonroot user and group
 RUN addgroup -S nonroot \
   && adduser -S nonroot -G nonroot
 
-# add ca-certificates
+# add ca-certificates and tzdata
 RUN apk --no-cache add ca-certificates tzdata
 
 # create workdir
 WORKDIR /root/
 
-# copy binary from first container
-COPY --from=0 /go/src/app .
+# copy binary from builder
+COPY --from=builder /go/src/app .
 
 # set user
 USER nonroot


### PR DESCRIPTION
This addresses issue with container being run with `nonroot` that results in permission denied.

fix #273