### PR TITLE
fix: invalid memory address or nil pointer dereference

### DIFF
--- a/src/webserver.go
+++ b/src/webserver.go
@@ -37,7 +37,7 @@ var (
 // main function
 func main() {
 	// setup of readyness endpoint code
-	isReady := &atomic.Value{}
+	isReady = &atomic.Value{}
 	isReady.Store(false)
 
 	// setting log parameters


### PR DESCRIPTION
error message when starting container:
```log
teslamate-teslamateapi-1 | panic: runtime error: invalid memory address or nil pointer dereference
teslamate-teslamateapi-1 | [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x47178e]
teslamate-teslamateapi-1 | 
teslamate-teslamateapi-1 | goroutine 1 [running]:
teslamate-teslamateapi-1 | sync/atomic.(*Value).Store(0x0, {0x8143c0, 0xbf6b68})
teslamate-teslamateapi-1 | 	/usr/local/go/src/sync/atomic/value.go:54 +0x2e
teslamate-teslamateapi-1 | main.startMQTT()
teslamate-teslamateapi-1 | 	/go/src/v1_TeslaMateAPICarsStatus.go:195 +0x857
teslamate-teslamateapi-1 | main.main()
teslamate-teslamateapi-1 | 	/go/src/webserver.go:67 +0x23b
```

rel #191