### PR TITLE
Converts the current speed if unit is "mi"

### DIFF
--- a/src/v1_TeslaMateAPICarsStatus.go
+++ b/src/v1_TeslaMateAPICarsStatus.go
@@ -711,6 +711,7 @@ func (s *statusCache) TeslaMateAPICarsStatusV1(c *gin.Context) {
 		// drive.OdometerDetails.OdometerStart = kilometersToMiles(drive.OdometerDetails.OdometerStart)
 		MQTTInformationData.Odometer = kilometersToMiles(MQTTInformationData.Odometer)
 		MQTTInformationData.DrivingDetails.ActiveRoute.DistanceToArrival = kilometersToMiles(MQTTInformationData.DrivingDetails.ActiveRoute.DistanceToArrival)
+		MQTTInformationData.DrivingDetails.Speed = kilometersToMiles(MQTTInformationData.DrivingDetails.Speed)
 		MQTTInformationData.BatteryDetails.EstBatteryRange = kilometersToMiles(MQTTInformationData.BatteryDetails.EstBatteryRange)
 		MQTTInformationData.BatteryDetails.RatedBatteryRange = kilometersToMiles(MQTTInformationData.BatteryDetails.RatedBatteryRange)
 		MQTTInformationData.BatteryDetails.IdealBatteryRange = kilometersToMiles(MQTTInformationData.BatteryDetails.IdealBatteryRange)


### PR DESCRIPTION
Adds a line to convert the current speed from KPH to MPH if the unit is "mi". 

Issue #300 