### PR TITLE
fix: status drivingdetails.speed to be int and not float64

### DIFF
--- a/src/v1_TeslaMateAPICarsStatus.go
+++ b/src/v1_TeslaMateAPICarsStatus.go
@@ -711,7 +711,7 @@ func (s *statusCache) TeslaMateAPICarsStatusV1(c *gin.Context) {
 		// drive.OdometerDetails.OdometerStart = kilometersToMiles(drive.OdometerDetails.OdometerStart)
 		MQTTInformationData.Odometer = kilometersToMiles(MQTTInformationData.Odometer)
 		MQTTInformationData.DrivingDetails.ActiveRoute.DistanceToArrival = kilometersToMiles(MQTTInformationData.DrivingDetails.ActiveRoute.DistanceToArrival)
-		MQTTInformationData.DrivingDetails.Speed = kilometersToMiles(MQTTInformationData.DrivingDetails.Speed)
+		MQTTInformationData.DrivingDetails.Speed = kilometersToMilesInteger(MQTTInformationData.DrivingDetails.Speed)
 		MQTTInformationData.BatteryDetails.EstBatteryRange = kilometersToMiles(MQTTInformationData.BatteryDetails.EstBatteryRange)
 		MQTTInformationData.BatteryDetails.RatedBatteryRange = kilometersToMiles(MQTTInformationData.BatteryDetails.RatedBatteryRange)
 		MQTTInformationData.BatteryDetails.IdealBatteryRange = kilometersToMiles(MQTTInformationData.BatteryDetails.IdealBatteryRange)

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -399,6 +399,11 @@ func milesToKilometersNilSupport(mi NullFloat64) NullFloat64 {
 }
 */
 
+// kilometersToMilesInteger func
+func kilometersToMilesInteger(km int) int {
+	return int(float64(km) * 0.62137119223733)
+}
+
 // barToPsi func
 func barToPsi(bar float64) float64 {
 	return (bar * 14.503773800722)


### PR DESCRIPTION
Error introduced in #299, where `MQTTInformationData.DrivingDetails.Speed` is in float64 format and not int.
Built [10348246519](https://github.com/tobiasehlert/teslamateapi/actions/runs/10348246519) failed, but this PR fixes issue.

rel #299 