### PR TITLE
Ability to use custom API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Basically the same environment variables for the database, mqqt and timezone nee
 | **MQTT_PASSWORD**     | string  |                                   |
 | **MQTT_NAMESPACE**    | string  |                                   |
 | **MQTT_CLIENTID**     | string  | _4 char random string_            |
-| **TESLA_API_URL**     | string  | https://owner-api.teslamotors.com |
+| **TESLA_API_HOST**    | string  | https://owner-api.teslamotors.com |
 
 **Commands** environment variables
 

--- a/README.md
+++ b/README.md
@@ -104,25 +104,25 @@ Basically the same environment variables for the database, mqqt and timezone nee
 
 **Optional** environment variables
 
-| Variable              | Type    | Default                           |
-|-----------------------|---------|-----------------------------------|
-| **TESLAMATE_SSL**     | boolean | _false_                           |
-| **TESLAMATE_HOST**    | string  | _teslamate_                       |
-| **TESLAMATE_PORT**    | string  | _4000_                            |
-| **API_TOKEN**         | string  |                                   |
-| **API_TOKEN_DISABLE** | string  | _false_                           |
-| **DATABASE_PORT**     | integer | _5432_                            |
-| **DATABASE_TIMEOUT**  | integer | _60000_                           |
-| **DATABASE_SSL**      | boolean | _true_                            |
-| **DEBUG_MODE**        | boolean | _false_                           |
-| **DISABLE_MQTT**      | boolean | _false_                           |
-| **MQTT_TLS**          | boolean | _false_                           |
-| **MQTT_PORT**         | integer | _1883 (if TLS is true: 8883)_     |
-| **MQTT_USERNAME**     | string  |                                   |
-| **MQTT_PASSWORD**     | string  |                                   |
-| **MQTT_NAMESPACE**    | string  |                                   |
-| **MQTT_CLIENTID**     | string  | _4 char random string_            |
-| **TESLA_API_HOST**    | string  | https://owner-api.teslamotors.com |
+| Variable              | Type    | Default                       |
+| --------------------- | ------- | ----------------------------- |
+| **TESLAMATE_SSL**     | boolean | _false_                       |
+| **TESLAMATE_HOST**    | string  | _teslamate_                   |
+| **TESLAMATE_PORT**    | string  | _4000_                        |
+| **API_TOKEN**         | string  |                               |
+| **API_TOKEN_DISABLE** | string  | _false_                       |
+| **DATABASE_PORT**     | integer | _5432_                        |
+| **DATABASE_TIMEOUT**  | integer | _60000_                       |
+| **DATABASE_SSL**      | boolean | _true_                        |
+| **DEBUG_MODE**        | boolean | _false_                       |
+| **DISABLE_MQTT**      | boolean | _false_                       |
+| **MQTT_TLS**          | boolean | _false_                       |
+| **MQTT_PORT**         | integer | _1883 (if TLS is true: 8883)_ |
+| **MQTT_USERNAME**     | string  |                               |
+| **MQTT_PASSWORD**     | string  |                               |
+| **MQTT_NAMESPACE**    | string  |                               |
+| **MQTT_CLIENTID**     | string  | _4 char random string_        |
+| **TESLA_API_HOST**    | string  | _retrieved by access token_   |
 
 **Commands** environment variables
 

--- a/README.md
+++ b/README.md
@@ -104,24 +104,25 @@ Basically the same environment variables for the database, mqqt and timezone nee
 
 **Optional** environment variables
 
-| Variable              | Type    | Default                       |
-| --------------------- | ------- | ----------------------------- |
-| **TESLAMATE_SSL**     | boolean | _false_                       |
-| **TESLAMATE_HOST**    | string  | _teslamate_                   |
-| **TESLAMATE_PORT**    | string  | _4000_                        |
-| **API_TOKEN**         | string  |                               |
-| **API_TOKEN_DISABLE** | string  | _false_                       |
-| **DATABASE_PORT**     | integer | _5432_                        |
-| **DATABASE_TIMEOUT**  | integer | _60000_                       |
-| **DATABASE_SSL**      | boolean | _true_                        |
-| **DEBUG_MODE**        | boolean | _false_                       |
-| **DISABLE_MQTT**      | boolean | _false_                       |
-| **MQTT_TLS**          | boolean | _false_                       |
-| **MQTT_PORT**         | integer | _1883 (if TLS is true: 8883)_ |
-| **MQTT_USERNAME**     | string  |                               |
-| **MQTT_PASSWORD**     | string  |                               |
-| **MQTT_NAMESPACE**    | string  |                               |
-| **MQTT_CLIENTID**     | string  | _4 char random string_        |
+| Variable              | Type    | Default                           |
+|-----------------------|---------|-----------------------------------|
+| **TESLAMATE_SSL**     | boolean | _false_                           |
+| **TESLAMATE_HOST**    | string  | _teslamate_                       |
+| **TESLAMATE_PORT**    | string  | _4000_                            |
+| **API_TOKEN**         | string  |                                   |
+| **API_TOKEN_DISABLE** | string  | _false_                           |
+| **DATABASE_PORT**     | integer | _5432_                            |
+| **DATABASE_TIMEOUT**  | integer | _60000_                           |
+| **DATABASE_SSL**      | boolean | _true_                            |
+| **DEBUG_MODE**        | boolean | _false_                           |
+| **DISABLE_MQTT**      | boolean | _false_                           |
+| **MQTT_TLS**          | boolean | _false_                           |
+| **MQTT_PORT**         | integer | _1883 (if TLS is true: 8883)_     |
+| **MQTT_USERNAME**     | string  |                                   |
+| **MQTT_PASSWORD**     | string  |                                   |
+| **MQTT_NAMESPACE**    | string  |                                   |
+| **MQTT_CLIENTID**     | string  | _4 char random string_            |
+| **TESLA_API_URL**     | string  | https://owner-api.teslamotors.com |
 
 **Commands** environment variables
 

--- a/src/v1_TeslaMateAPICarsCommand.go
+++ b/src/v1_TeslaMateAPICarsCommand.go
@@ -112,9 +112,9 @@ func TeslaMateAPICarsCommandV1(c *gin.Context) {
 
 	switch getCarRegionAPI(TeslaAccessToken) {
 	case ChinaAPI:
-		TeslaEndpointUrl = getEnv("TESLA_API_URL", "https://owner-api.vn.cloud.tesla.cn")
+		TeslaEndpointUrl = getEnv("TESLA_API_HOST", "https://owner-api.vn.cloud.tesla.cn")
 	default:
-		TeslaEndpointUrl = getEnv("TESLA_API_URL", "https://owner-api.teslamotors.com")
+		TeslaEndpointUrl = getEnv("TESLA_API_HOST", "https://owner-api.teslamotors.com")
 	}
 
 	client := &http.Client{}

--- a/src/v1_TeslaMateAPICarsCommand.go
+++ b/src/v1_TeslaMateAPICarsCommand.go
@@ -112,9 +112,9 @@ func TeslaMateAPICarsCommandV1(c *gin.Context) {
 
 	switch getCarRegionAPI(TeslaAccessToken) {
 	case ChinaAPI:
-		TeslaEndpointUrl = "https://owner-api.vn.cloud.tesla.cn"
+		TeslaEndpointUrl = getEnv("TESLA_API_URL", "https://owner-api.vn.cloud.tesla.cn")
 	default:
-		TeslaEndpointUrl = "https://owner-api.teslamotors.com"
+		TeslaEndpointUrl = getEnv("TESLA_API_URL", "https://owner-api.teslamotors.com")
 	}
 
 	client := &http.Client{}

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -74,7 +74,11 @@ func main() {
 	}
 
 	if getEnvAsBool("API_TOKEN_DISABLE", false) {
-		log.Println("[warning] validateAuthToken - header authorization bearer token disabled. Authorizaiton: Bearer token will not be required for commands.")
+		log.Println("[warning] validateAuthToken - header authorization bearer token disabled. Authorization: Bearer token will not be required for commands.")
+	}
+
+	if teslaApiHost := os.Getenv("TESLA_API_HOST"); teslaApiHost != "" {
+		log.Printf("[info] TESLA_API_HOST is set: %s\n", teslaApiHost)
 	}
 
 	// kicking off Gin in value r

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -77,7 +77,7 @@ func main() {
 		log.Println("[warning] validateAuthToken - header authorization bearer token disabled. Authorization: Bearer token will not be required for commands.")
 	}
 
-	if teslaApiHost := os.Getenv("TESLA_API_HOST"); teslaApiHost != "" {
+	if teslaApiHost := getEnv("TESLA_API_HOST", ""); teslaApiHost != "" {
 		log.Printf("[info] TESLA_API_HOST is set: %s\n", teslaApiHost)
 	}
 

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -78,7 +78,7 @@ func main() {
 	}
 
 	if teslaApiHost := getEnv("TESLA_API_HOST", ""); teslaApiHost != "" {
-		log.Printf("[info] TESLA_API_HOST is set: %s\n", teslaApiHost)
+		log.Println("[info] TESLA_API_HOST is set: %s", teslaApiHost)
 	}
 
 	// kicking off Gin in value r


### PR DESCRIPTION
As already discussed #255 #292 the official Tesla API will be the only way to send commands.

Using third-party Tesla API providers (or a self-hosted commands proxy) would allow command endpoints to be preserved.

I added an environment variable to allow users to choose their API provider.