### PR TITLE
feat: add latitude and longitude to charges

### DIFF
--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -49,6 +49,8 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 		RangeRated        PreferredRange `json:"range_rated"`         // PreferredRange
 		OutsideTempAvg    float64        `json:"outside_temp_avg"`    // float64
 		Odometer          float64        `json:"odometer"`            // float64
+		Latitude          float64        `json:"latitude"`            // float64
+		Longitude         float64        `json:"longitude"`           // float64
 	}
 	// TeslaMateUnits struct - child of Data
 	type TeslaMateUnits struct {
@@ -101,6 +103,8 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 			TO_CHAR((duration_min * INTERVAL '1 minute'), 'HH24:MI') as duration_str,
 			outside_temp_avg,
 			position.odometer as odometer,
+			position.latitude,
+			position.longitude,
 			(SELECT unit_of_length FROM settings LIMIT 1) as unit_of_length,
 			(SELECT unit_of_temperature FROM settings LIMIT 1) as unit_of_temperature,
 			cars.name
@@ -148,6 +152,8 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 			&charge.DurationStr,
 			&charge.OutsideTempAvg,
 			&charge.Odometer,
+			&charge.Latitude,
+			&charge.Longitude,
 			&UnitsLength,
 			&UnitsTemperature,
 			&CarName,

--- a/src/v1_TeslaMateAPICarsChargesDetails.go
+++ b/src/v1_TeslaMateAPICarsChargesDetails.go
@@ -89,9 +89,9 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 		RangeRated        PreferredRange  `json:"range_rated"`         // PreferredRange
 		OutsideTempAvg    float64         `json:"outside_temp_avg"`    // float64
 		Odometer          float64         `json:"odometer"`            // float64
-		ChargeDetails     []ChargeDetails `json:"charge_details"`      // struct
 		Latitude          float64         `json:"latitude"`            // float64
 		Longitude         float64         `json:"longitude"`           // float64
+		ChargeDetails     []ChargeDetails `json:"charge_details"`      // struct
 	}
 	// TeslaMateUnits struct - child of Data
 	type TeslaMateUnits struct {

--- a/src/v1_TeslaMateAPICarsChargesDetails.go
+++ b/src/v1_TeslaMateAPICarsChargesDetails.go
@@ -90,6 +90,8 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 		OutsideTempAvg    float64         `json:"outside_temp_avg"`    // float64
 		Odometer          float64         `json:"odometer"`            // float64
 		ChargeDetails     []ChargeDetails `json:"charge_details"`      // struct
+		Latitude          float64         `json:"latitude"`            // float64
+		Longitude         float64         `json:"longitude"`           // float64
 	}
 	// TeslaMateUnits struct - child of Data
 	type TeslaMateUnits struct {
@@ -137,7 +139,9 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 			position.odometer as odometer,
 			(SELECT unit_of_length FROM settings LIMIT 1) as unit_of_length,
 			(SELECT unit_of_temperature FROM settings LIMIT 1) as unit_of_temperature,
-			cars.name
+			cars.name,
+			position.latitude,
+			position.longitude
 		FROM charging_processes
 		LEFT JOIN cars ON car_id = cars.id
 		LEFT JOIN addresses address ON address_id = address.id
@@ -170,6 +174,8 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 		&UnitsLength,
 		&UnitsTemperature,
 		&CarName,
+		&charge.Latitude,
+		&charge.Longitude,
 	)
 
 	switch err {

--- a/src/v1_TeslaMateAPICarsChargesDetails.go
+++ b/src/v1_TeslaMateAPICarsChargesDetails.go
@@ -137,11 +137,11 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 			TO_CHAR((duration_min * INTERVAL '1 minute'), 'HH24:MI') as duration_str,
 			outside_temp_avg,
 			position.odometer as odometer,
+			position.latitude,
+			position.longitude,
 			(SELECT unit_of_length FROM settings LIMIT 1) as unit_of_length,
 			(SELECT unit_of_temperature FROM settings LIMIT 1) as unit_of_temperature,
-			cars.name,
-			position.latitude,
-			position.longitude
+			cars.name
 		FROM charging_processes
 		LEFT JOIN cars ON car_id = cars.id
 		LEFT JOIN addresses address ON address_id = address.id
@@ -171,11 +171,11 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 		&charge.DurationStr,
 		&charge.OutsideTempAvg,
 		&charge.Odometer,
+		&charge.Latitude,
+		&charge.Longitude,
 		&UnitsLength,
 		&UnitsTemperature,
 		&CarName,
-		&charge.Latitude,
-		&charge.Longitude,
 	)
 
 	switch err {


### PR DESCRIPTION
Feature to show latitude and longitude in charge details.

- Added latitude and longitude fields to charge data in the API response
- Values are sourced from the position table in the database
- No unit conversion is applied to coordinates (they remain in decimal degrees)