### PR TITLE
feat: add support for filtering on start and end date

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,15 +162,15 @@ More detailed documentation of every endpoint will come..
 - GET `/api/v1/cars/:CarID`
 - GET `/api/v1/cars/:CarID/charges`
   - Supported parameters:
-    - `startDate` (optional, the format must be `2025-07-18T16:26:28`)
-    - `endDate` (optional, the format must be `2025-07-18T16:26:28`) 
+    - `startDate` (optional, the format must be `YYYY-MM-DDTHH:MM:SS`)
+    - `endDate` (optional, the format must be `YYYY-MM-DDTHH:MM:SS`) 
 - GET `/api/v1/cars/:CarID/charges/:ChargeID`
 - GET `/api/v1/cars/:CarID/command`
 - POST `/api/v1/cars/:CarID/command/:Command`
 - GET `/api/v1/cars/:CarID/drives`
   - Supported parameters:
-    - `startDate` (optional, the format must be `2025-07-18T16:26:28`)
-    - `endDate` (optional, the format must be `2025-07-18T16:26:28`) 
+    - `startDate` (optional, the format must be `YYYY-MM-DDTHH:MM:SS`)
+    - `endDate` (optional, the format must be `YYYY-MM-DDTHH:MM:SS`) 
 - GET `/api/v1/cars/:CarID/drives/:DriveID`
 - PUT `/api/v1/cars/:CarID/logging/:Command`
 - GET `/api/v1/cars/:CarID/logging`

--- a/README.md
+++ b/README.md
@@ -161,10 +161,16 @@ More detailed documentation of every endpoint will come..
 - GET `/api/v1/cars`
 - GET `/api/v1/cars/:CarID`
 - GET `/api/v1/cars/:CarID/charges`
+  - Supported parameters:
+    - `startDate` (optional, the format must be `2025-07-18T16:26:28`)
+    - `endDate` (optional, the format must be `2025-07-18T16:26:28`) 
 - GET `/api/v1/cars/:CarID/charges/:ChargeID`
 - GET `/api/v1/cars/:CarID/command`
 - POST `/api/v1/cars/:CarID/command/:Command`
 - GET `/api/v1/cars/:CarID/drives`
+  - Supported parameters:
+    - `startDate` (optional, the format must be `2025-07-18T16:26:28`)
+    - `endDate` (optional, the format must be `2025-07-18T16:26:28`) 
 - GET `/api/v1/cars/:CarID/drives/:DriveID`
 - PUT `/api/v1/cars/:CarID/logging/:Command`
 - GET `/api/v1/cars/:CarID/logging`
@@ -175,6 +181,7 @@ More detailed documentation of every endpoint will come..
 - GET `/api/healthz`
 - GET `/api/ping`
 - GET `/api/readyz`
+
 
 ### Authentication
 

--- a/README.md
+++ b/README.md
@@ -162,15 +162,15 @@ More detailed documentation of every endpoint will come..
 - GET `/api/v1/cars/:CarID`
 - GET `/api/v1/cars/:CarID/charges`
   - Supported parameters:
-    - `startDate` (optional, the format must be `YYYY-MM-DDTHH:MM:SS`)
-    - `endDate` (optional, the format must be `YYYY-MM-DDTHH:MM:SS`) 
+    - `startDate` (optional, use canonical UTC format in RFC3339)
+    - `endDate` (optional, use canonical UTC format in RFC3339)
 - GET `/api/v1/cars/:CarID/charges/:ChargeID`
 - GET `/api/v1/cars/:CarID/command`
 - POST `/api/v1/cars/:CarID/command/:Command`
 - GET `/api/v1/cars/:CarID/drives`
   - Supported parameters:
-    - `startDate` (optional, the format must be `YYYY-MM-DDTHH:MM:SS`)
-    - `endDate` (optional, the format must be `YYYY-MM-DDTHH:MM:SS`) 
+    - `startDate` (optional, use canonical UTC format in RFC3339)
+    - `endDate` (optional, use canonical UTC format in RFC3339)
 - GET `/api/v1/cars/:CarID/drives/:DriveID`
 - PUT `/api/v1/cars/:CarID/logging/:Command`
 - GET `/api/v1/cars/:CarID/logging`
@@ -182,6 +182,8 @@ More detailed documentation of every endpoint will come..
 - GET `/api/ping`
 - GET `/api/readyz`
 
+> [!TIP]
+> Canonical UTC format in RFC3339, e.g. `2006-01-02T15:04:05Z` or `2006-01-02T15:04:05+07:00`
 
 ### Authentication
 

--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -12,7 +12,7 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 
 	// define error messages
 	var CarsChargesError1 = "Unable to load charges."
-	var CarsChargesError2 = "Invalid date format. Please use YYYY-MM-DDTHH:MM:SS format."
+	var CarsChargesError2 = "Invalid date format."
 
 	// getting CarID param from URL
 	CarID := convertStringToInteger(c.Param("CarID"))
@@ -20,15 +20,15 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 	ResultPage := convertStringToInteger(c.DefaultQuery("page", "1"))
 	ResultShow := convertStringToInteger(c.DefaultQuery("show", "100"))
 
-	parsedStartDate, err := parseDateParam(c, "startDate")
+	// get startDate and endDate from query parameters
+	parsedStartDate, err := parseDateParam(c.Query("startDate"))
 	if err != nil {
-		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesV1", CarsChargesError2, fmt.Sprintf("Invalid startDate: %s", err.Error()))
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesV1", CarsChargesError2, err.Error())
 		return
 	}
-
-	parsedEndDate, err := parseDateParam(c, "endDate")
+	parsedEndDate, err := parseDateParam(c.Query("endDate"))
 	if err != nil {
-		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesV1", CarsChargesError2, fmt.Sprintf("Invalid endDate: %s", err.Error()))
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsChargesV1", CarsChargesError2, err.Error())
 		return
 	}
 

--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -12,7 +12,7 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 
 	// define error messages
 	var CarsChargesError1 = "Unable to load charges."
-	var CarsChargesError2 = "Invalid date format. Please use 2025-07-18T16:26:28 format."
+	var CarsChargesError2 = "Invalid date format. Please use YYYY-MM-DDTHH:MM:SS format."
 
 	// getting CarID param from URL
 	CarID := convertStringToInteger(c.Param("CarID"))

--- a/src/v1_TeslaMateAPICarsDrives.go
+++ b/src/v1_TeslaMateAPICarsDrives.go
@@ -12,7 +12,7 @@ func TeslaMateAPICarsDrivesV1(c *gin.Context) {
 
 	// define error messages
 	var CarsDrivesError1 = "Unable to load drives."
-	var CarsDrivesError2 = "Invalid date format. Please use 2025-07-18T16:26:28 format."
+	var CarsDrivesError2 = "Invalid date format. Please use YYYY-MM-DDTHH:MM:SS format."
 
 	// getting CarID param from URL
 	CarID := convertStringToInteger(c.Param("CarID"))

--- a/src/v1_TeslaMateAPICarsDrives.go
+++ b/src/v1_TeslaMateAPICarsDrives.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/gin-gonic/gin"
 	_ "github.com/lib/pq"
 )
@@ -10,12 +12,25 @@ func TeslaMateAPICarsDrivesV1(c *gin.Context) {
 
 	// define error messages
 	var CarsDrivesError1 = "Unable to load drives."
+	var CarsDrivesError2 = "Invalid date format. Please use 2025-07-18T16:26:28 format."
 
 	// getting CarID param from URL
 	CarID := convertStringToInteger(c.Param("CarID"))
 	// query options to modify query when collecting data
 	ResultPage := convertStringToInteger(c.DefaultQuery("page", "1"))
 	ResultShow := convertStringToInteger(c.DefaultQuery("show", "100"))
+
+	parsedStartDate, err := parseDateParam(c, "startDate")
+	if err != nil {
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesV1", CarsDrivesError2, fmt.Sprintf("Invalid startDate: %s", err.Error()))
+		return
+	}
+
+	parsedEndDate, err := parseDateParam(c, "endDate")
+	if err != nil {
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesV1", CarsDrivesError2, fmt.Sprintf("Invalid endDate: %s", err.Error()))
+		return
+	}
 
 	// creating structs for /cars/<CarID>/drives
 	// Car struct - child of Data
@@ -137,10 +152,32 @@ func TeslaMateAPICarsDrivesV1(c *gin.Context) {
 		LEFT JOIN positions end_position ON end_position_id = end_position.id
 		LEFT JOIN geofences start_geofence ON start_geofence_id = start_geofence.id
 		LEFT JOIN geofences end_geofence ON end_geofence_id = end_geofence.id
-		WHERE drives.car_id=$1 AND end_date IS NOT NULL
-		ORDER BY start_date DESC
-		LIMIT $2 OFFSET $3;`
-	rows, err := db.Query(query, CarID, ResultShow, ResultPage)
+		WHERE drives.car_id=$1 AND end_date IS NOT NULL`
+
+	// Parameters to be passed to the query
+	var queryParams []interface{}
+	queryParams = append(queryParams, CarID)
+	paramIndex := 2
+
+	// Add date filtering if provided
+	if parsedStartDate != "" {
+		query += fmt.Sprintf(" AND drives.start_date >= $%d", paramIndex)
+		queryParams = append(queryParams, parsedStartDate)
+		paramIndex++
+	}
+	if parsedEndDate != "" {
+		query += fmt.Sprintf(" AND drives.end_date <= $%d", paramIndex)
+		queryParams = append(queryParams, parsedEndDate)
+		paramIndex++
+	}
+
+	query += fmt.Sprintf(`
+        ORDER BY start_date DESC
+        LIMIT $%d OFFSET $%d;`, paramIndex, paramIndex+1)
+
+	queryParams = append(queryParams, ResultShow, ResultPage)
+
+	rows, err := db.Query(query, queryParams...)
 
 	// checking for errors in query
 	if err != nil {

--- a/src/v1_TeslaMateAPICarsDrives.go
+++ b/src/v1_TeslaMateAPICarsDrives.go
@@ -12,7 +12,7 @@ func TeslaMateAPICarsDrivesV1(c *gin.Context) {
 
 	// define error messages
 	var CarsDrivesError1 = "Unable to load drives."
-	var CarsDrivesError2 = "Invalid date format. Please use YYYY-MM-DDTHH:MM:SS format."
+	var CarsDrivesError2 = "Invalid date format."
 
 	// getting CarID param from URL
 	CarID := convertStringToInteger(c.Param("CarID"))
@@ -20,15 +20,15 @@ func TeslaMateAPICarsDrivesV1(c *gin.Context) {
 	ResultPage := convertStringToInteger(c.DefaultQuery("page", "1"))
 	ResultShow := convertStringToInteger(c.DefaultQuery("show", "100"))
 
-	parsedStartDate, err := parseDateParam(c, "startDate")
+	// get startDate and endDate from query parameters
+	parsedStartDate, err := parseDateParam(c.Query("startDate"))
 	if err != nil {
-		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesV1", CarsDrivesError2, fmt.Sprintf("Invalid startDate: %s", err.Error()))
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesV1", CarsDrivesError2, err.Error())
 		return
 	}
-
-	parsedEndDate, err := parseDateParam(c, "endDate")
+	parsedEndDate, err := parseDateParam(c.Query("endDate"))
 	if err != nil {
-		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesV1", CarsDrivesError2, fmt.Sprintf("Invalid endDate: %s", err.Error()))
+		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsDrivesV1", CarsDrivesError2, err.Error())
 		return
 	}
 

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -300,7 +301,8 @@ func parseDateParam(datestring string) (string, error) {
 
 	// validate that the datestring is in RFC3339 format
 	if _, err := time.Parse(time.RFC3339, datestring); err != nil {
-		return "", fmt.Errorf("invalid date format: %s, please use RFC3339 format", datestring)
+		sanitizedInput := strings.NewReplacer("\n", "\\n", "\r", "\\r", "\t", "\\t").Replace(datestring)
+		return "", fmt.Errorf("invalid date format: %s, please use RFC3339 format", sanitizedInput)
 	}
 
 	// parse and validate the date string

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -298,7 +298,7 @@ func parseDateParam(datestring string) (string, error) {
 		return "", nil
 	}
 
-	// validate that the datestring is in RFC3336 format
+	// validate that the datestring is in RFC3339 format
 	if _, err := time.Parse(time.RFC3339, datestring); err != nil {
 		return "", fmt.Errorf("invalid date format: %s, please use canonical UTC format in RFC3339", datestring)
 	}

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -305,7 +305,8 @@ func parseDateParam(datestring string) (string, error) {
 	}
 
 	// DateTime format (2006-01-02 15:04:05) without timezone info, interpret in user's timezone
-	if t, err := time.ParseInLocation(time.DateTime, strings.ReplaceAll(datestring, "T", " "), appUsersTimezone); err == nil {
+	normalizedDateString := strings.ReplaceAll(datestring, "T", " ")
+	if t, err := time.ParseInLocation(time.DateTime, normalizedDateString, appUsersTimezone); err == nil {
 		return t.UTC().Format(dbTimestampFormat), nil
 	}
 

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -22,8 +22,9 @@ var (
 	// application readyz endpoint value for k8s
 	isReady *atomic.Value
 
-	// setting TeslaMateApi version number
-	apiVersion = "unspecified"
+	// setting TeslaMateApi parameters
+	apiVersion        = "unspecified"
+	dbTimestampFormat = "2006-01-02T15:04:05Z" // format used in postgres for dates
 
 	// defining db var
 	db *sql.DB
@@ -33,6 +34,9 @@ var (
 
 	// list of allowed commands
 	allowList []string
+
+	// app-settings
+	appUsersTimezone *time.Location
 )
 
 // main function
@@ -53,6 +57,12 @@ func main() {
 		// setting GIN_MODE to DebugMode
 		gin.SetMode(gin.DebugMode)
 		log.Printf("[info] TeslaMateApi running in debug mode.")
+	}
+
+	// getting app-settings from environment
+	appUsersTimezone, _ = time.LoadLocation(getEnv("TZ", "Europe/Berlin"))
+	if gin.IsDebugging() {
+		log.Println("[debug] TeslaMateApi appUsersTimezone:", appUsersTimezone)
 	}
 
 	// init of API with connection to database
@@ -270,25 +280,15 @@ func TeslaMateAPIHandleSuccessResponse(c *gin.Context, s string, j interface{}) 
 }
 
 func getTimeInTimeZone(datestring string) string {
-
-	// getting timezone from environment
-	UsersTimezone := getEnv("TZ", "Europe/Berlin")
-
-	// format the dates are stored in postgres
-	TeslaMateDateFormat := "2006-01-02T15:04:05Z"
-
-	// parsing datestring into TeslaMateDateFormat
-	t, _ := time.Parse(TeslaMateDateFormat, datestring)
-
-	// loading timezone location
-	UserLocation, _ := time.LoadLocation(UsersTimezone)
+	// parsing datestring into dbTimestampFormat
+	t, _ := time.Parse(dbTimestampFormat, datestring)
 
 	// formatting in users location in RFC3339 format
-	ReturnDate := t.In(UserLocation).Format(time.RFC3339)
+	ReturnDate := t.In(appUsersTimezone).Format(time.RFC3339)
 
 	// logging time conversion to log
 	if gin.IsDebugging() {
-		log.Println("[debug] getTimeInTimeZone - UTC", t.Format(time.RFC3339), "time converted to", UsersTimezone, "is", ReturnDate)
+		log.Println("[debug] getTimeInTimeZone - UTC", t.Format(time.RFC3339), "time converted to", appUsersTimezone, "is", ReturnDate)
 	}
 
 	return ReturnDate
@@ -299,15 +299,19 @@ func parseDateParam(datestring string) (string, error) {
 		return "", nil
 	}
 
-	// validate that the datestring is in RFC3339 format
-	parsedTime, err := time.Parse(time.RFC3339, datestring)
-	if err != nil {
-		sanitizedInput := strings.NewReplacer("\n", "\\n", "\r", "\\r", "\t", "\\t").Replace(datestring)
-		return "", fmt.Errorf("invalid date format: %s, please use RFC3339 format", sanitizedInput)
+	// RFC3339 formats first — includes Z or timezone offset
+	if t, err := time.Parse(time.RFC3339, datestring); err == nil {
+		return t.UTC().Format(dbTimestampFormat), nil
 	}
 
-	// return the parsed time in UTC format with Z (as used in the database)
-	return parsedTime.UTC().Format("2006-01-02T15:04:05Z"), nil
+	// local timestamp without timezone info, interpret in user's timezone
+	const naiveLayout = "2006-01-02T15:04:05"
+	if t, err := time.ParseInLocation(naiveLayout, datestring, appUsersTimezone); err == nil {
+		return t.UTC().Format(dbTimestampFormat), nil
+	}
+
+	sanitizedInput := strings.NewReplacer("\n", "\\n", "\r", "\\r", "\t", "\\t").Replace(datestring)
+	return "", fmt.Errorf("invalid date format: %s, please use RFC3339 format", sanitizedInput)
 }
 
 /*

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -49,7 +49,7 @@ func parseAndValidateDate(dateParam string) (string, error) {
 	}
 
 	// parsing datestring as user's local time
-	parsedTime, parseErr := time.ParseInLocation("2025-07-18T16:26:28", dateParam, UserLocation)
+	parsedTime, parseErr := time.ParseInLocation("2006-01-02T15:04:05", dateParam, UserLocation)
 
 	if parseErr != nil {
 		return "", fmt.Errorf("invalid date format '%s': %s", dateParam, parseErr.Error())

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -300,13 +300,14 @@ func parseDateParam(datestring string) (string, error) {
 	}
 
 	// validate that the datestring is in RFC3339 format
-	if _, err := time.Parse(time.RFC3339, datestring); err != nil {
+	parsedTime, err := time.Parse(time.RFC3339, datestring)
+	if err != nil {
 		sanitizedInput := strings.NewReplacer("\n", "\\n", "\r", "\\r", "\t", "\\t").Replace(datestring)
 		return "", fmt.Errorf("invalid date format: %s, please use RFC3339 format", sanitizedInput)
 	}
 
-	// parse and validate the date string
-	return getTimeInTimeZone(datestring), nil
+	// return the parsed time in UTC format with Z (as used in the database)
+	return parsedTime.UTC().Format("2006-01-02T15:04:05Z"), nil
 }
 
 /*

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -304,9 +304,8 @@ func parseDateParam(datestring string) (string, error) {
 		return t.UTC().Format(dbTimestampFormat), nil
 	}
 
-	// local timestamp without timezone info, interpret in user's timezone
-	const naiveLayout = "2006-01-02T15:04:05"
-	if t, err := time.ParseInLocation(naiveLayout, datestring, appUsersTimezone); err == nil {
+	// DateTime format (2006-01-02 15:04:05) without timezone info, interpret in user's timezone
+	if t, err := time.ParseInLocation(time.DateTime, strings.ReplaceAll(datestring, "T", " "), appUsersTimezone); err == nil {
 		return t.UTC().Format(dbTimestampFormat), nil
 	}
 

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -34,6 +34,38 @@ var (
 	allowList []string
 )
 
+func parseAndValidateDate(dateParam string) (string, error) {
+	if dateParam == "" {
+		return "", nil
+	}
+
+	// getting timezone from environment
+	UsersTimezone := getEnv("TZ", "Europe/Berlin")
+
+	// loading timezone location
+	UserLocation, locationErr := time.LoadLocation(UsersTimezone)
+	if locationErr != nil {
+		return "", fmt.Errorf("invalid timezone '%s': %s", UsersTimezone, locationErr.Error())
+	}
+
+	// parsing datestring as user's local time
+	parsedTime, parseErr := time.ParseInLocation("2025-07-18T16:26:28", dateParam, UserLocation)
+
+	if parseErr != nil {
+		return "", fmt.Errorf("invalid date format '%s': %s", dateParam, parseErr.Error())
+	}
+
+	return parsedTime.UTC().Format("2006-01-02 15:04:05"), nil
+}
+
+func parseDateParam(c *gin.Context, paramName string) (string, error) {
+	dateStr := c.DefaultQuery(paramName, "")
+	if dateStr == "" {
+		return "", nil
+	}
+	return parseAndValidateDate(dateStr)
+}
+
 // main function
 func main() {
 	// setup of readyness endpoint code

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -300,7 +300,7 @@ func parseDateParam(datestring string) (string, error) {
 
 	// validate that the datestring is in RFC3339 format
 	if _, err := time.Parse(time.RFC3339, datestring); err != nil {
-		return "", fmt.Errorf("invalid date format: %s, please use canonical UTC format in RFC3339", datestring)
+		return "", fmt.Errorf("invalid date format: %s, please use RFC3339 format", datestring)
 	}
 
 	// parse and validate the date string


### PR DESCRIPTION
This PR adds support for `startDate` and `endDate` in the following endpoints:

```url
api/v1/cars/1/charges
api/v1/cars/1/drives
```

use it like this:

```url
api/v1/cars/1/drives?startDate=2025-06-20T21:10:27+02:00&endDate=2025-06-22T21:10:27+02:00
api/v1/cars/1/charges?startDate=2025-06-20T17:37:48+02:00
```