### PR TITLE
fix(docker): adjust chmod permissions on binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apk --no-cache add ca-certificates tzdata && \
 USER nonroot:nonroot
 
 # copy binary from builder
-COPY --from=builder --chown=nonroot:nonroot --chmod=755 /go/src/app .
+COPY --from=builder --chown=nonroot:nonroot --chmod=555 /go/src/app .
 
 # expose port 8080
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apk --no-cache add ca-certificates tzdata && \
 USER nonroot:nonroot
 
 # copy binary from builder
-COPY --from=builder --chown=nonroot:nonroot --chmod=544 /go/src/app .
+COPY --from=builder --chown=nonroot:nonroot --chmod=755 /go/src/app .
 
 # expose port 8080
 EXPOSE 8080


### PR DESCRIPTION
When in Kubernetes another user is set (via `runAsUser`), such as `65534`, the binary fails to start because other doesn't have the execute flag on the `app` binary.

This PR fixes it.