### PR TITLE
feat: add distance filtering for drives

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ More detailed documentation of every endpoint will come..
   - Supported parameters:
     - `startDate` (optional, use canonical UTC format in RFC3339)
     - `endDate` (optional, use canonical UTC format in RFC3339)
-    - `minDistance` (optional, filter by minimum trip distance)
-    - `maxDistance` (optional, filter by maximum trip distance)
+    - `minDistance` (optional, filter by minimum trip distance, units based on TeslaMate settings)
+    - `maxDistance` (optional, filter by maximum trip distance, units based on TeslaMate settings)
 - GET `/api/v1/cars/:CarID/drives/:DriveID`
 - PUT `/api/v1/cars/:CarID/logging/:Command`
 - GET `/api/v1/cars/:CarID/logging`

--- a/src/v1_TeslaMateAPICarsDrives.go
+++ b/src/v1_TeslaMateAPICarsDrives.go
@@ -203,7 +203,16 @@ func TeslaMateAPICarsDrivesV1(c *gin.Context) {
 	// Add minimum/maximum distance filtering if provided
 	if minDistance > 0 || maxDistance > 0 {
 		var unitsLength string
-		_ = db.QueryRow("SELECT unit_of_length FROM settings LIMIT 1").Scan(&unitsLength)
+		err = db.QueryRow("SELECT unit_of_length FROM settings LIMIT 1").Scan(&unitsLength)
+		if err != nil {
+			TeslaMateAPIHandleErrorResponse(
+				c,
+				"TeslaMateAPICarsDrivesV1",
+				CarsDrivesError1,
+				fmt.Sprintf("unable to retrieve unit_of_length from settings table: %v", err),
+			)
+			return
+		}
 		if unitsLength == "mi" {
 			if minDistance > 0 {
 				minDistance = milesToKilometers(minDistance)


### PR DESCRIPTION
- Adds optional `minDistance` and `maxDistance` query params to `GET /api/v1/cars/:CarID/drives` for distance filtering.
- Accepts floating‑point values (e.g., 1.5); dot decimal; negatives are ignored (0 or missing = no filter).
- Respects `settings.unit_of_length` (mi/km); miles are converted to kilometers internally to match the database.
- Params can be used independently or together.

Example
- `GET /api/v1/cars/1/drives?minDistance=1.5&maxDistance=12`