### PR TITLE
feat: add api-version header into responses

### DIFF
--- a/src/webserver.go
+++ b/src/webserver.go
@@ -98,7 +98,7 @@ func main() {
 	r.Use(gzip.Gzip(gzip.DefaultCompression))
 
 	r.Use(func(c *gin.Context) {
-		c.Writer.Header().Set(headerAPIVersion, apiVersion)
+		c.Header(headerAPIVersion, apiVersion)
 		c.Next()
 	})
 


### PR DESCRIPTION
- adding `API-Version` header to every response
- fixing typos
- moving `dbTimestampFormat` to constant

fix #384