### PR TITLE
Add options to set battery capacity and range settings when new

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Basically the same environment variables for the database, mqqt and timezone nee
 | **MQTT_NAMESPACE**            | string  |                               |
 | **MQTT_CLIENTID**             | string  | _4 char random string_        |
 | **TESLA_API_HOST**            | string  | _retrieved by access token_   |
+| **BATTERY_MAX_CAPACITY_NEW**  | string  | Max battery capacity when new (format: `carId:value,carId2:value`) |
+| **MAX_RANGE_NEW**  | string  | Max range when new (format: `carId:value,carId2:value`) |
 
 **Commands** environment variables
 

--- a/src/v1_TeslaMateAPICarsBatteryHealth.go
+++ b/src/v1_TeslaMateAPICarsBatteryHealth.go
@@ -47,8 +47,11 @@ func TeslaMateAPICarsBatteryHealthV1(c *gin.Context) {
 		Efficiency                    float64
 		MaxRangeRated                 float64
 		MaxRangeIdeal                 float64
+		MaxRangeRatedDB               float64
+		MaxRangeIdealDB               float64
 		CurrentRangeRated             float64
 		CurrentRangeIdeal             float64
+		MaxCapacityDB                 float64
 		MaxCapacity                   float64
 		CurrentCapacity               float64
 		PreferredRange                string
@@ -253,11 +256,11 @@ func TeslaMateAPICarsBatteryHealthV1(c *gin.Context) {
 
 	// execute query
 	err := db.QueryRow(query, CarID).Scan(
-		&MaxRangeRated,
-		&MaxRangeIdeal,
+		&MaxRangeRatedDB,
+		&MaxRangeIdealDB,
 		&CurrentRangeRated,
 		&CurrentRangeIdeal,
-		&MaxCapacity,
+		&MaxCapacityDB,
 		&CurrentCapacity,
 		&Efficiency,
 		&PreferredRange,
@@ -270,6 +273,22 @@ func TeslaMateAPICarsBatteryHealthV1(c *gin.Context) {
 	if err != nil {
 		TeslaMateAPIHandleErrorResponse(c, "TeslaMateAPICarsBatteryHealthV1", CarsBatteryHealthError1, err.Error())
 		return
+	}
+
+	// Check if there's a specific max capacity configured for this car
+	if maxCapacityNew, exists := batteryMaxCapacityNewMap[CarID]; exists {
+		MaxCapacity = maxCapacityNew
+	} else {
+		MaxCapacity = MaxCapacityDB
+	}
+
+	// Check if there's a specific max range configured for this car
+	if maxRangeNew, exists := maxRangeNewMap[CarID]; exists {
+		MaxRangeRated = maxRangeNew
+		MaxRangeIdeal = maxRangeNew
+	} else {
+		MaxRangeRated = MaxRangeRatedDB
+		MaxRangeIdeal = MaxRangeIdealDB
 	}
 
 	// Create battery health object


### PR DESCRIPTION
This PR adds env variables to configure initial battery capacity and range. This will allow for proper battery health stats even when tesla mate does not have the full dataset since the purchase of the vehicle.