### PR TITLE
fix: handle NULL model field in cars endpoint

### DIFF
--- a/src/v1_TeslaMateAPICars.go
+++ b/src/v1_TeslaMateAPICars.go
@@ -24,7 +24,7 @@ func TeslaMateAPICarsV1(c *gin.Context) {
 		EID         int64       `json:"eid"`          // bigint
 		VID         int64       `json:"vid"`          // bigint
 		Vin         string      `json:"vin"`          // text
-		Model       string      `json:"model"`        // character varying(255)
+		Model       NullString  `json:"model"`        // character varying(255)
 		TrimBadging NullString  `json:"trim_badging"` // text
 		Efficiency  NullFloat64 `json:"efficiency"`   // double precision
 	}


### PR DESCRIPTION
- Cybertruck may have NULL model value in database, causing scan error.
- Closes https://github.com/tobiasehlert/teslamateapi/issues/429