### PR TITLE
fix: prefix table names for start_date and end_date in charge queries

### DIFF
--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -102,8 +102,8 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 	query := `
 		SELECT
 			charging_processes.id AS charge_id,
-			start_date,
-			end_date,
+			charging_processes.start_date,
+			charging_processes.end_date,
 			COALESCE(geofence.name, CONCAT_WS(', ', COALESCE(address.name, nullif(CONCAT_WS(' ', address.road, address.house_number), '')), address.city)) AS address,
 			COALESCE(charge_energy_added, 0) AS charge_energy_added,
 			COALESCE(GREATEST(charge_energy_used, charge_energy_added), 0) AS charge_energy_used,

--- a/src/v1_TeslaMateAPICarsChargesDetails.go
+++ b/src/v1_TeslaMateAPICarsChargesDetails.go
@@ -121,8 +121,8 @@ func TeslaMateAPICarsChargesDetailsV1(c *gin.Context) {
 	query := `
 		SELECT
 			charging_processes.id AS charge_id,
-			start_date,
-			end_date,
+			charging_processes.start_date,
+			charging_processes.end_date,
 			COALESCE(geofence.name, CONCAT_WS(', ', COALESCE(address.name, nullif(CONCAT_WS(' ', address.road, address.house_number), '')), address.city)) AS address,
 			COALESCE(charging_processes.charge_energy_added, 0) AS charge_energy_added,
 			COALESCE(GREATEST(charge_energy_used, charging_processes.charge_energy_added), 0) AS charge_energy_used,


### PR DESCRIPTION
Fixes an issue that caused some users to see the error: `Unable to load charge.; pq: column reference "end_date" is ambiguous.`