### PR TITLE
fix: handle nullable outside_temp_avg in charges endpoint

### DIFF
--- a/src/v1_TeslaMateAPICarsCharges.go
+++ b/src/v1_TeslaMateAPICarsCharges.go
@@ -62,7 +62,7 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 		BatteryDetails    BatteryDetails `json:"battery_details"`     // BatteryDetails
 		RangeIdeal        PreferredRange `json:"range_ideal"`         // PreferredRange
 		RangeRated        PreferredRange `json:"range_rated"`         // PreferredRange
-		OutsideTempAvg    float64        `json:"outside_temp_avg"`    // float64
+		OutsideTempAvg    *float64       `json:"outside_temp_avg"`    // float64
 		Odometer          float64        `json:"odometer"`            // float64
 		Latitude          float64        `json:"latitude"`            // float64
 		Longitude         float64        `json:"longitude"`           // float64
@@ -206,7 +206,10 @@ func TeslaMateAPICarsChargesV1(c *gin.Context) {
 		}
 		// converting values based of settings UnitsTemperature
 		if UnitsTemperature == "F" {
-			charge.OutsideTempAvg = celsiusToFahrenheit(charge.OutsideTempAvg)
+			if charge.OutsideTempAvg != nil {
+				val := celsiusToFahrenheit(*charge.OutsideTempAvg)
+				charge.OutsideTempAvg = &val
+			}
 		}
 
 		// adjusting to timezone differences from UTC to be userspecific


### PR DESCRIPTION
This PR should fix issues like the following:

```
[GIN] 2026/04/09 - 08:44:07 | 200 |    12.285108ms |       172.18.0.4 | GET      "/api/v1/cars/1/charges?page=4&show=100"
2026/04/09 08:44:07.317641 [error] TeslaMateAPICarsChargesV1 - (/api/v1/cars/1/charges?page=5&show=100). Unable to load
charges.; sql: Scan error on column index 15, name "outside_temp_avg": converting NULL to float64 is unsupported
[GIN] 2026/04/09 - 08:44:07 | 200 |    10.640027ms |       172.18.0.4 | GET      "/api/v1/cars/1/charges?page=5&show=100"
```


Use *float64 for OutsideTempAvg to prevent scan error when outside_temp_avg is NULL in the database.

