### PR TITLE
fix(ci): move workflow permissions to job level

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,6 @@ on:
     types: [published]
   workflow_dispatch:
 
-permissions:
-  attestations: write
-  contents: read
-  id-token: write
-  packages: write
-
 concurrency:
   group: build-${{ github.workflow }}-${{ github.ref }}
 
@@ -27,6 +21,11 @@ jobs:
     name: build (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     if: github.event_name != 'pull_request'
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
 
     strategy:
       fail-fast: false
@@ -128,6 +127,11 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
 
     outputs:
       docker_build_digest: ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,6 +266,8 @@ jobs:
     needs:
       - build
       - manifest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,14 +8,13 @@ on:
   schedule:
     - cron: "44 15 * * 0"
 
-permissions:
-  contents: read
-  security-events: write
-
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Move permissions from workflow-level to job-level for build and manifest jobs in build.yml, and analyze job in codeql-analysis.yml to comply with githubactions:S8233 security best practices.