### PR TITLE
feat: support configurable API token header

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Basically the same environment variables for the database, mqqt and timezone nee
 | **TESLAMATE_HOST**            | string  | _teslamate_                   |
 | **TESLAMATE_PORT**            | string  | _4000_                        |
 | **API_TOKEN**                 | string  |                               |
+| **API_TOKEN_HEADER**          | string  | _Authorization_               |
 | **API_TOKEN_DISABLE**         | string  | _false_                       |
 | **DATABASE_PORT**             | integer | _5432_                        |
 | **DATABASE_TIMEOUT**          | integer | _60000_                       |
@@ -196,9 +197,10 @@ If you want to use command or logging endpoints such as `/api/v1/cars/:CarID/com
 
 You need to specify a token yourself (called **API_TOKEN**) in the environment variables file, to set it. The token has the requirement to be a minimum of 32 characters long.
 
-There are two options available for authentication to be done.
+There are two main options available for authentication:
 
 1. Adding extra header `Authorization: Bearer <token>` to your request. (recommended option)
+   - Alternatively set `API_TOKEN_HEADER` to a custom header name (for example `X-API-Token`) and send the raw token in that header: `X-API-Token: <token>` (no "Bearer" prefix).
 
 2. Adding URI parameter `?token=<token>` to the endpoint you try to reach. (not a good option)
 

--- a/src/AuthSupport.go
+++ b/src/AuthSupport.go
@@ -35,74 +35,66 @@ func initAuthToken() {
 	log.Printf("[info] initAuthToken - using header for API token: %s", apiTokenHeaderName)
 }
 
+// helper to extract token from configured header
+func extractTokenFromHeader(headerName, headerValue string) (string, string) {
+	if strings.EqualFold(headerName, "Authorization") {
+		// expecting format: Authorization: Bearer <token>
+		splitToken := strings.Split(headerValue, "Bearer")
+		// bearer token is not proper formatted.. returning bad request
+		if len(splitToken) != 2 {
+			return "", "header authorization bearer token is not proper formatted"
+		}
+		trimmed := strings.TrimSpace(splitToken[1])
+		if trimmed == "" {
+			return "", "header authorization bearer token is empty"
+		}
+		return trimmed, ""
+	}
+
+	// custom header - treat value as raw token (no Bearer prefix)
+	trimmed := strings.TrimSpace(headerValue)
+	if trimmed == "" {
+		return "", "header token empty"
+	}
+	return trimmed, ""
+}
+
 // validateAuthToken func
 func validateAuthToken(c *gin.Context) (bool, string) {
-
 	// if API_TOKEN_DISABLE is true, skip token validation.
 	if getEnvAsBool("API_TOKEN_DISABLE", false) {
 		log.Println("[debug] validateAuthToken - header authorization bearer token disabled.")
 		return true, ""
 	}
 
-	// trying with configured http header
-	reqHeaderToken := c.Request.Header.Get(apiTokenHeaderName)
-
-	// if header provided
-	if len(reqHeaderToken) > 0 {
-
+	// try configured header first
+	headerVal := c.Request.Header.Get(apiTokenHeaderName)
+	if headerVal != "" {
+		token, errMsg := extractTokenFromHeader(apiTokenHeaderName, headerVal)
+		if errMsg != "" {
+			log.Println("[info] validateAuthToken -", errMsg+".. returning 401")
+			return false, errMsg
+		}
+		if checkAuthToken(token) {
+			log.Println("[debug] validateAuthToken - token from header valid.")
+			return true, ""
+		}
+		// invalid token from header
 		if strings.EqualFold(apiTokenHeaderName, "Authorization") {
-			// expecting format: Authorization: Bearer <token>
-			splitToken := strings.Split(reqHeaderToken, "Bearer")
-
-			// bearer token is not proper formatted.. returning bad request
-			if len(splitToken) != 2 {
-				log.Println("[info] validateAuthToken - header authorization bearer token is not proper formatted.. returning 401")
-				return false, "header authorization bearer token is not proper formatted"
-
-			} else if strings.TrimSpace(splitToken[1]) == "" {
-				log.Println("[info] validateAuthToken - header authorization bearer token is empty.. returning 401")
-				return false, "header authorization bearer token is empty"
-
-			} else if checkAuthToken(strings.TrimSpace(splitToken[1])) {
-				// the bearer token is valid!
-				log.Println("[debug] validateAuthToken - header authorization bearer token valid.")
-				return true, ""
-
-			}
-			// the check did fail.. bearer token is invalid
 			log.Println("[info] validateAuthToken - header authorization bearer token invalid.. returning 401")
 			return false, "header authorization bearer token invalid"
-
-		} else {
-			// custom header - treat value as raw token (no Bearer prefix)
-			tokenValue := strings.TrimSpace(reqHeaderToken)
-			if tokenValue == "" {
-				log.Println("[info] validateAuthToken - configured header value is empty.. returning 401")
-				return false, "header token empty"
-			}
-			if checkAuthToken(tokenValue) {
-				log.Println("[debug] validateAuthToken - token from custom header valid.")
-				return true, ""
-			}
-			log.Println("[info] validateAuthToken - token from custom header invalid.. returning 401")
-			return false, "header token invalid"
 		}
+		log.Println("[info] validateAuthToken - header token invalid.. returning 401")
+		return false, "header token invalid"
 	}
 
-	// trying with http parameter - ?token=<token>
+	// fallback to query parameter ?token=<token>
 	tokenParamsValue := c.DefaultQuery("token", "")
-
-	// if validTokenParams is longer than zero
-	if len(tokenParamsValue) > 0 {
-
-		// checking if token is valid (since it's over zero length)
+	if tokenParamsValue != "" {
 		if checkAuthToken(tokenParamsValue) {
-			// the token is valid!
 			log.Println("[debug] validateAuthToken - param token valid.")
 			return true, ""
-
 		}
-		// the token is invalid.
 		log.Println("[info] validateAuthToken - param token invalid.. returning 401")
 		return false, "param token invalid"
 	}

--- a/src/AuthSupport.go
+++ b/src/AuthSupport.go
@@ -10,12 +10,20 @@ import (
 var (
 	// defining envToken that contains API_TOKEN value
 	envToken string
+	// header name to read API token from (default "Authorization")
+	apiTokenHeaderName string
 )
 
 // initAuthToken func
 func initAuthToken() {
 	// get token from environment variable API_TOKEN
 	envToken = getEnv("API_TOKEN", "")
+	// get header name from environment variable API_TOKEN_HEADER (default: Authorization)
+	apiTokenHeaderName = getEnv("API_TOKEN_HEADER", "Authorization")
+	if apiTokenHeaderName == "" {
+		apiTokenHeaderName = "Authorization"
+	}
+
 	if envToken == "" {
 		log.Println("[warning] initAuthToken - environment variable API_TOKEN not set or is empty.")
 	} else if len(envToken) < 32 {
@@ -23,6 +31,8 @@ func initAuthToken() {
 	} else {
 		log.Println("[info] initAuthToken - environment variable API_TOKEN is set and good.")
 	}
+
+	log.Printf("[info] initAuthToken - using header for API token: %s", apiTokenHeaderName)
 }
 
 // validateAuthToken func
@@ -34,34 +44,54 @@ func validateAuthToken(c *gin.Context) (bool, string) {
 		return true, ""
 	}
 
-	// trying with http header - Authorization: Bearer <token>
-	reqHeaderToken := c.Request.Header.Get("Authorization")
+	headersName := apiTokenHeaderName
+	if headersName == "" {
+		headersName = "Authorization"
+	}
 
-	// if length of reqHeaderToken is more than zero
+	// trying with configured http header
+	reqHeaderToken := c.Request.Header.Get(headersName)
+
+	// if header provided
 	if len(reqHeaderToken) > 0 {
 
-		// removing Bearer part from header to get token out of header
-		splitToken := strings.Split(reqHeaderToken, "Bearer")
+		if strings.EqualFold(headersName, "Authorization") {
+			// expecting format: Authorization: Bearer <token>
+			splitToken := strings.Split(reqHeaderToken, "Bearer")
 
-		if len(splitToken) != 2 {
 			// bearer token is not proper formatted.. returning bad request
-			log.Println("[info] validateAuthToken - header authorization bearer token is not proper formatted.. returning 401")
-			return false, "header authorization bearer token is not proper formatted"
+			if len(splitToken) != 2 {
+				log.Println("[info] validateAuthToken - header authorization bearer token is not proper formatted.. returning 401")
+				return false, "header authorization bearer token is not proper formatted"
 
-		} else if strings.TrimSpace(splitToken[1]) == "" {
-			// bearer token is empty string.. we'll return unauthorized
-			log.Println("[info] validateAuthToken - header authorization bearer token is empty.. returning 401")
-			return false, "header authorization bearer token is empty"
+			} else if strings.TrimSpace(splitToken[1]) == "" {
+				log.Println("[info] validateAuthToken - header authorization bearer token is empty.. returning 401")
+				return false, "header authorization bearer token is empty"
 
-		} else if checkAuthToken(strings.TrimSpace(splitToken[1])) {
-			// the bearer token is valid!
-			log.Println("[debug] validateAuthToken - header authorization bearer token valid.")
-			return true, ""
+			} else if checkAuthToken(strings.TrimSpace(splitToken[1])) {
+				// the bearer token is valid!
+				log.Println("[debug] validateAuthToken - header authorization bearer token valid.")
+				return true, ""
 
+			}
+			// the check did fail.. bearer token is invalid
+			log.Println("[info] validateAuthToken - header authorization bearer token invalid.. returning 401")
+			return false, "header authorization bearer token invalid"
+
+		} else {
+			// custom header - treat value as raw token (no Bearer prefix)
+			tokenValue := strings.TrimSpace(reqHeaderToken)
+			if tokenValue == "" {
+				log.Println("[info] validateAuthToken - configured header value is empty.. returning 401")
+				return false, "header token empty"
+			}
+			if checkAuthToken(tokenValue) {
+				log.Println("[debug] validateAuthToken - token from custom header valid.")
+				return true, ""
+			}
+			log.Println("[info] validateAuthToken - token from custom header invalid.. returning 401")
+			return false, "header token invalid"
 		}
-		// the check did fail.. bearer token is invalid
-		log.Println("[info] validateAuthToken - header authorization bearer token invalid.. returning 401")
-		return false, "header authorization bearer token invalid"
 	}
 
 	// trying with http parameter - ?token=<token>

--- a/src/AuthSupport.go
+++ b/src/AuthSupport.go
@@ -44,18 +44,13 @@ func validateAuthToken(c *gin.Context) (bool, string) {
 		return true, ""
 	}
 
-	headersName := apiTokenHeaderName
-	if headersName == "" {
-		headersName = "Authorization"
-	}
-
 	// trying with configured http header
-	reqHeaderToken := c.Request.Header.Get(headersName)
+	reqHeaderToken := c.Request.Header.Get(apiTokenHeaderName)
 
 	// if header provided
 	if len(reqHeaderToken) > 0 {
 
-		if strings.EqualFold(headersName, "Authorization") {
+		if strings.EqualFold(apiTokenHeaderName, "Authorization") {
 			// expecting format: Authorization: Bearer <token>
 			splitToken := strings.Split(reqHeaderToken, "Bearer")
 


### PR DESCRIPTION
Why

The API currently only accepts the API token via the Authorization: Bearer <token> header or as a ?token query parameter. Some deployments and proxies make it convenient to use a different header (for example X-API-Token). This change makes the header configurable so operators can choose which header carries the API token.

What changed / approach

- Added API_TOKEN_HEADER env var (defaults to "Authorization").
- src/AuthSupport.go reads API_TOKEN_HEADER during init and uses it in validateAuthToken.
  - When API_TOKEN_HEADER is "Authorization", the existing "Bearer <token>" parsing is preserved.
  - For custom headers (e.g., X-API-Token) the header value is treated as the raw token (no "Bearer" prefix expected).
- README.md: documented API_TOKEN_HEADER and added usage notes for both default and custom header scenarios.

Notes / testing

- Backwards compatible: default behavior unchanged.
- Built locally (go build) and ran a smoke build; recommend running the binary with API_TOKEN and trying both Authorization: Bearer <token> and a custom header like X-API-Token: <token>.

Fixes: #481