### PR TITLE
fix(sonar): group consecutive parameters of the same type (S8209)

### DIFF
--- a/src/EncryptionSupport.go
+++ b/src/EncryptionSupport.go
@@ -21,7 +21,7 @@ const (
 )
 
 // decryptAccessToken funct to decrypt tokens from database
-func decryptAccessToken(data string, encryptionKey string) string {
+func decryptAccessToken(data, encryptionKey string) string {
 
 	/*
 	   From Adrian....

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -330,7 +330,7 @@ func parseDateParam(datestring string) (string, error) {
 }
 
 // getEnv func - read an environment or return a default value
-func getEnv(key string, defaultVal string) string {
+func getEnv(key, defaultVal string) string {
 	if value, exists := os.LookupEnv(key); exists && value != "" {
 		return value
 	}


### PR DESCRIPTION
## Problem
SonarQube rule S8209 requires that consecutive function parameters of the same type should be grouped together for better readability and idiomatic Go style.

## Solution
Grouped consecutive string parameters in two functions:

- `decryptAccessToken`: Changed from `(data string, encryptionKey string)` to `(data, encryptionKey string)`
- `getEnv`: Changed from `(key string, defaultVal string)` to `(key, defaultVal string)`

## Changes
- **src/EncryptionSupport.go**: Updated `decryptAccessToken` function signature
- **src/webserver.go**: Updated `getEnv` function signature

Both functions retain the same functionality while improving code style per Go conventions.