### PR TITLE
fix(drives): handle nullable temperature fields for old drive records

### DIFF
--- a/src/v1_TeslaMateAPICarsDrives.go
+++ b/src/v1_TeslaMateAPICarsDrives.go
@@ -95,8 +95,8 @@ func TeslaMateAPICarsDrivesV1(c *gin.Context) {
 		BatteryDetails    BatteryDetails  `json:"battery_details"`     // BatteryDetails
 		RangeIdeal        PreferredRange  `json:"range_ideal"`         // PreferredRange
 		RangeRated        PreferredRange  `json:"range_rated"`         // PreferredRange
-		OutsideTempAvg    float64         `json:"outside_temp_avg"`    // float64
-		InsideTempAvg     float64         `json:"inside_temp_avg"`     // float64
+		OutsideTempAvg    *float64        `json:"outside_temp_avg"`    // float64 (nullable)
+		InsideTempAvg     *float64        `json:"inside_temp_avg"`     // float64 (nullable)
 		EnergyConsumedNet *float64        `json:"energy_consumed_net"` // Energy consumed (net) in kWh
 		ConsumptionNet    *float64        `json:"consumption_net"`     // Ø Consumption (net) per distance unit
 	}
@@ -331,8 +331,12 @@ func TeslaMateAPICarsDrivesV1(c *gin.Context) {
 		}
 		// converting values based of settings UnitsTemperature
 		if UnitsTemperature == "F" {
-			drive.OutsideTempAvg = celsiusToFahrenheit(drive.OutsideTempAvg)
-			drive.InsideTempAvg = celsiusToFahrenheit(drive.InsideTempAvg)
+			if drive.OutsideTempAvg != nil {
+				*drive.OutsideTempAvg = celsiusToFahrenheit(*drive.OutsideTempAvg)
+			}
+			if drive.InsideTempAvg != nil {
+				*drive.InsideTempAvg = celsiusToFahrenheit(*drive.InsideTempAvg)
+			}
 		}
 
 		// adjusting to timezone differences from UTC to be userspecific

--- a/src/v1_TeslaMateAPICarsDrivesDetails.go
+++ b/src/v1_TeslaMateAPICarsDrivesDetails.go
@@ -99,8 +99,8 @@ func TeslaMateAPICarsDrivesDetailsV1(c *gin.Context) {
 		BatteryDetails    BatteryDetails  `json:"battery_details"`     // BatteryDetails
 		RangeIdeal        PreferredRange  `json:"range_ideal"`         // PreferredRange
 		RangeRated        PreferredRange  `json:"range_rated"`         // PreferredRange
-		OutsideTempAvg    float64         `json:"outside_temp_avg"`    // float64
-		InsideTempAvg     float64         `json:"inside_temp_avg"`     // float64
+		OutsideTempAvg    *float64        `json:"outside_temp_avg"`    // float64 (nullable)
+		InsideTempAvg     *float64        `json:"inside_temp_avg"`     // float64 (nullable)
 		EnergyConsumedNet *float64        `json:"energy_consumed_net"` // Energy consumed (net) in kWh
 		ConsumptionNet    *float64        `json:"consumption_net"`     // Ø Consumption (net) per distance unit
 		DriveDetails      []DriveDetails  `json:"drive_details"`       // struct
@@ -252,8 +252,12 @@ func TeslaMateAPICarsDrivesDetailsV1(c *gin.Context) {
 	}
 	// converting values based of settings UnitsTemperature
 	if UnitsTemperature == "F" {
-		drive.OutsideTempAvg = celsiusToFahrenheit(drive.OutsideTempAvg)
-		drive.InsideTempAvg = celsiusToFahrenheit(drive.InsideTempAvg)
+		if drive.OutsideTempAvg != nil {
+			*drive.OutsideTempAvg = celsiusToFahrenheit(*drive.OutsideTempAvg)
+		}
+		if drive.InsideTempAvg != nil {
+			*drive.InsideTempAvg = celsiusToFahrenheit(*drive.InsideTempAvg)
+		}
 	}
 	// adjusting to timezone differences from UTC to be userspecific
 	drive.StartDate = getTimeInTimeZone(drive.StartDate)


### PR DESCRIPTION
Fixes #500 where drives without temperature data (older records or recovered drives from database recovery) would cause scan errors.

## Problem
When querying drives with `inside_temp_avg` or `outside_temp_avg` set to NULL in the database, the code crashed with:
```
Scan error on column index 27, name "inside_temp_avg": converting NULL to float64 is unsupported
```

## Solution
Changed `OutsideTempAvg` and `InsideTempAvg` from non-nullable `float64` to nullable `*float64` to match the database schema where these columns can be NULL. Updated the temperature conversion logic to safely handle nil pointers by checking for nil before dereferencing.

Applied the fix to both:
- `/api/v1/cars/<CarID>/drives` endpoint
- `/api/v1/cars/<CarID>/drives/<DriveID>` endpoint (drives details)

This allows querying drives with missing temperature data without errors, which is essential for users recovering old drives or dealing with data gaps in their records.