### PR TITLE
fix: handle NULL car profile fields in /api/v1/cars

### DIFF
--- a/src/v1_TeslaMateAPICars.go
+++ b/src/v1_TeslaMateAPICars.go
@@ -30,9 +30,9 @@ func TeslaMateAPICarsV1(c *gin.Context) {
 	}
 	// CarExterior struct - child of Cars
 	type CarExterior struct {
-		ExteriorColor string `json:"exterior_color"` // text
-		SpoilerType   string `json:"spoiler_type"`   // text
-		WheelType     string `json:"wheel_type"`     // text
+		ExteriorColor NullString `json:"exterior_color"` // text
+		SpoilerType   NullString `json:"spoiler_type"`   // text
+		WheelType     NullString `json:"wheel_type"`     // text
 	}
 	// CarSettings struct - child of Cars
 	type CarSettings struct {


### PR DESCRIPTION
This fixes a corner case on fresh TeslaMate setups where the car can still be offline/asleep and some profile fields in `cars` remain `NULL`. In that window, `/api/v1/cars` could fail while scanning nullable text columns into Go `string` fields.

This change makes the endpoint resilient by scanning `exterior_color`, `spoiler_type`, and `wheel_type` as `NullString`, matching the existing handling for `trim_badging`. That keeps the response working until TeslaMate has populated the full vehicle profile.

This is intentionally scoped to the cars endpoint. Other endpoints may have their own nullable-field handling and were not changed here.

Fixes: #477